### PR TITLE
feat: implement sparse (thin provisioning) parameter for iSCSI zvols

### DIFF
--- a/pkg/client/storage.go
+++ b/pkg/client/storage.go
@@ -109,6 +109,7 @@ type DatasetCreateOptions struct {
 	RecordSize      string         `json:"recordsize,omitempty"`
 	Volsize         int64          `json:"volsize,omitempty"` // For ZVOLs
 	Volblocksize    string         `json:"volblocksize,omitempty"`
+	Sparse          *bool          `json:"sparse,omitempty"` // Thin provisioning for ZVOLs
 	Comments        string         `json:"comments,omitempty"`
 	CreateAncestors bool           `json:"create_ancestors,omitempty"`
 	Properties      map[string]any `json:"properties,omitempty"`

--- a/pkg/client/storage_test.go
+++ b/pkg/client/storage_test.go
@@ -60,6 +60,67 @@ func TestCreateDataset_ZVOL(t *testing.T) {
 	assertEqual(t, dataset.Volsize, int64(1073741824))
 }
 
+func TestCreateDataset_SparseZVOL(t *testing.T) {
+	mock := NewMockTrueNASServer()
+	defer mock.Close()
+
+	mock.SetResponse(methodDatasetCreate, MockResponse{
+		Result: MockZVOL("tank/sparse-vol", "sparse-vol", "tank", 1073741824),
+	})
+
+	client := connectTestClient(t, mock)
+
+	sparse := true
+	opts := &DatasetCreateOptions{
+		Name:    "tank/sparse-vol",
+		Type:    "VOLUME",
+		Volsize: 1073741824,
+		Sparse:  &sparse,
+	}
+	dataset, err := client.CreateDataset(testContext(t), opts)
+
+	assertNoError(t, err)
+	assertNotNil(t, dataset)
+	assertEqual(t, dataset.Type, "VOLUME")
+	assertEqual(t, dataset.Volsize, int64(1073741824))
+
+	requests := mock.GetRequestsByMethod(methodDatasetCreate)
+	assertLen(t, requests, 1)
+	var params []any
+	json.Unmarshal(requests[0].Params, &params)
+	createOpts := params[0].(map[string]any)
+	assertTrue(t, createOpts["sparse"].(bool))
+}
+
+func TestCreateDataset_ThickZVOL_NoSparseField(t *testing.T) {
+	mock := NewMockTrueNASServer()
+	defer mock.Close()
+
+	mock.SetResponse(methodDatasetCreate, MockResponse{
+		Result: MockZVOL("tank/thick-vol", "thick-vol", "tank", 1073741824),
+	})
+
+	client := connectTestClient(t, mock)
+
+	opts := &DatasetCreateOptions{
+		Name:    "tank/thick-vol",
+		Type:    "VOLUME",
+		Volsize: 1073741824,
+	}
+	dataset, err := client.CreateDataset(testContext(t), opts)
+
+	assertNoError(t, err)
+	assertNotNil(t, dataset)
+
+	requests := mock.GetRequestsByMethod(methodDatasetCreate)
+	assertLen(t, requests, 1)
+	var params []any
+	json.Unmarshal(requests[0].Params, &params)
+	createOpts := params[0].(map[string]any)
+	_, hasSparse := createOpts["sparse"]
+	assertFalse(t, hasSparse)
+}
+
 func TestCreateDataset_WithEncryption(t *testing.T) {
 	mock := NewMockTrueNASServer()
 	defer mock.Close()
@@ -1213,6 +1274,30 @@ func TestDatasetCreateOptions_JSONEncoding(t *testing.T) {
 	// Should NOT have encryption (false)
 	_, hasEncryption := decoded["encryption"]
 	assertFalse(t, hasEncryption)
+
+	// Sparse nil pointer should be omitted
+	_, hasSparse := decoded["sparse"]
+	assertFalse(t, hasSparse)
+}
+
+func TestDatasetCreateOptions_JSONEncoding_WithSparse(t *testing.T) {
+	sparse := true
+	opts := &DatasetCreateOptions{
+		Name:    "tank/sparse",
+		Type:    "VOLUME",
+		Volsize: 1073741824,
+		Sparse:  &sparse,
+	}
+
+	data, err := json.Marshal(opts)
+	assertNoError(t, err)
+
+	var decoded map[string]any
+	json.Unmarshal(data, &decoded)
+
+	sparseVal, hasSparse := decoded["sparse"]
+	assertTrue(t, hasSparse)
+	assertTrue(t, sparseVal.(bool))
 }
 
 func TestZFSProperty_GetInt64(t *testing.T) {

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -69,6 +69,7 @@ const (
 	paramCompression  = "compression"
 	paramSync         = "sync"
 	paramVolBlockSize = "volblocksize"
+	paramSparse       = "sparse"
 
 	// iSCSI parameters
 	paramISCSIBlockSize  = "iscsi.blocksize"
@@ -220,6 +221,14 @@ func (s *ControllerServer) validateStorageClassParameters(ctx context.Context, p
 		}
 		if _, valid := ValidISCSIBlockSizes[bs]; !valid {
 			return fmt.Errorf("invalid iscsi.blocksize: %s (valid: 512, 1024, 2048, 4096)", val)
+		}
+	}
+
+	// Validate sparse (must be "true" or "false")
+	if val, ok := parameters[paramSparse]; ok {
+		lower := strings.ToLower(val)
+		if lower != "true" && lower != "false" {
+			return fmt.Errorf("invalid sparse value: %s (valid: true, false)", val)
 		}
 	}
 
@@ -648,6 +657,12 @@ func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, data
 		Properties:   make(map[string]any),
 	}
 
+	if val, ok := parameters[paramSparse]; ok && strings.EqualFold(val, "true") {
+		sparse := true
+		datasetOpts.Sparse = &sparse
+		s.driver.Log().V(LogLevelDebug).Info("Enabling sparse (thin) provisioning for ZVOL", "dataset", datasetPath)
+	}
+
 	for key, value := range parameters {
 		if propName, found := strings.CutPrefix(key, "zfs."); found {
 			datasetOpts.Properties[propName] = value
@@ -889,7 +904,13 @@ func (s *ControllerServer) createVolumeFromSource(ctx context.Context, req *csi.
 			updateOpts := &client.DatasetUpdateOptions{}
 			if protocol == ProtocolISCSI {
 				updateOpts.Volsize = &requiredBytes
-				updateOpts.RefReservation = &requiredBytes
+				clonedDs, err := s.driver.Client().GetDataset(ctx, datasetPath)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "failed to query cloned dataset for sparse detection: %v", err)
+				}
+				if clonedDs.RefReservation > 0 {
+					updateOpts.RefReservation = &requiredBytes
+				}
 			} else {
 				updateOpts.RefQuota = &requiredBytes
 			}
@@ -966,7 +987,13 @@ func (s *ControllerServer) createVolumeFromSource(ctx context.Context, req *csi.
 			updateOpts := &client.DatasetUpdateOptions{}
 			if protocol == ProtocolISCSI {
 				updateOpts.Volsize = &requiredBytes
-				updateOpts.RefReservation = &requiredBytes
+				clonedDs, err := s.driver.Client().GetDataset(ctx, datasetPath)
+				if err != nil {
+					return nil, status.Errorf(codes.Internal, "failed to query cloned dataset for sparse detection: %v", err)
+				}
+				if clonedDs.RefReservation > 0 {
+					updateOpts.RefReservation = &requiredBytes
+				}
 			} else {
 				updateOpts.RefQuota = &requiredBytes
 			}
@@ -1799,7 +1826,15 @@ func (s *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi.
 	updates := &client.DatasetUpdateOptions{}
 	if volInfo.Protocol == ProtocolISCSI {
 		updates.Volsize = &newSize
-		updates.RefReservation = &newSize // Must update reservation to match volsize
+
+		dataset, err := s.driver.Client().GetDataset(ctx, volInfo.DatasetPath)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to query dataset for sparse detection: %v", err)
+		}
+		// Sparse (thin) zvols have refreservation == 0; only update reservation for thick zvols
+		if dataset.RefReservation > 0 {
+			updates.RefReservation = &newSize
+		}
 	} else {
 		updates.RefQuota = &newSize
 	}


### PR DESCRIPTION
The sparse StorageClass parameter was documented but never wired into the pool.dataset.create WebSocket RPC payload. Add the Sparse field to DatasetCreateOptions, parse the parameter in createISCSIVolume, validate it in validateStorageClassParameters, and preserve thin provisioning on volume expansion and clone resize by checking refreservation before setting it.

This solve #16 