### PR TITLE
Allow overriding CSI driver name via CSI_DRIVER_NAME env var

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -99,6 +99,14 @@ func validateFlags() error {
 }
 
 func loadEnvConfig(config *driver.DriverConfig) error {
+	// Optional: override the CSI driver name (default: csi.truenas.io).
+	// Allows running multiple truenas-csi instances in a single cluster,
+	// each pointing at a different TrueNAS appliance, by giving each a
+	// unique CSIDriver name (e.g. "tenant-a.csi.truenas.io"). The kubelet
+	// socket path and CSIDriver CR name in the deployment manifests must
+	// match the value set here.
+	config.DriverName = os.Getenv("CSI_DRIVER_NAME")
+
 	if val := os.Getenv("TRUENAS_URL"); val == "" {
 		return fmt.Errorf("TRUENAS_URL is missing")
 	} else {

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -257,7 +257,9 @@ type DriverConfig struct {
 // It validates the configuration, establishes a connection to TrueNAS,
 // and initializes the controller and node services.
 func NewDriver(config *DriverConfig) (*Driver, error) {
-	config.DriverName = DRIVER_NAME
+	if config.DriverName == "" {
+		config.DriverName = DRIVER_NAME
+	}
 
 	config.DriverVersion = DRIVER_VERSION
 


### PR DESCRIPTION
Closes #19.

Adds CSI_DRIVER_NAME env var override so operators can run multiple
truenas-csi instances in one cluster, each pointing at a different
TrueNAS appliance. Backward compatible — existing deployments that
don't set CSI_DRIVER_NAME keep the default csi.truenas.io name.

See #19 for the full motivation (per-project TrueNAS VM
topology, one VM per Rancher project — hardcoded CSIDriver name
means only one truenas-csi per cluster today).

Testing:
- Applied on a fresh v1.0.2 clone, compiles clean with go 1.24.5.
- With CSI_DRIVER_NAME unset, driver reports csi.truenas.io (unchanged).
- With CSI_DRIVER_NAME=tenant-a.csi.truenas.io, driver registers
  under that name.
