### PR TITLE
Dockerfile: install e2fsprogs-extra + xfsprogs-extra so resize2fs/xfs_growfs are present (fixes #25)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,13 @@ ARG VERSION=dev
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X github.com/truenas/truenas-csi/pkg/driver.DRIVER_VERSION=${VERSION}" -o truenas-csi-driver cmd/main.go
 
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates nfs-utils open-iscsi e2fsprogs xfsprogs util-linux
+# On Alpine, `resize2fs` lives in `e2fsprogs-extra` (not the base `e2fsprogs`),
+# and `xfs_growfs` lives in `xfsprogs-extra`. The CSI driver calls both during
+# MountDevice (idempotent FS-resize after attach) and NodeExpandVolume (for
+# PVCs with allowVolumeExpansion=true). Without the -extra packages the driver
+# returns "executable file not found in $PATH" on every fresh mount and
+# silently fails to grow the filesystem on PVC expansion. See issue #25.
+RUN apk add --no-cache ca-certificates nfs-utils open-iscsi \
+    e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra util-linux
 COPY --from=builder /build/truenas-csi-driver /truenas-csi-driver
 ENTRYPOINT ["/truenas-csi-driver"]


### PR DESCRIPTION
## Summary

Fixes #25. On Alpine, `resize2fs` lives in `e2fsprogs-extra` (not base `e2fsprogs`), and `xfs_growfs` lives in `xfsprogs-extra` (not base `xfsprogs`). The current `apk add e2fsprogs xfsprogs` builds an image that contains `mkfs.ext4`, `mkfs.xfs`, `e2fsck`, `xfs_repair`, etc., but NOT the two resize tools the driver actually calls at runtime.

## Change

```diff
 FROM alpine:3.19
-RUN apk add --no-cache ca-certificates nfs-utils open-iscsi e2fsprogs xfsprogs util-linux
+RUN apk add --no-cache ca-certificates nfs-utils open-iscsi \
+    e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra util-linux
```

Plus an inline comment explaining the Alpine packaging gotcha so the next editor doesn't drop the `-extra` packages.

## Why it matters

1. **First-mount of every iSCSI PVC fails once.** `MountDevice` calls `resize2fs`, gets `executable file not found in $PATH`, returns error. kubelet retries, the second attempt skips the resize step (the FS is already mounted), and the volume eventually attaches. Cost: ~30s extra first-mount latency + noisy `FailedMount` events.
2. **Volume expansion silently breaks.** `allowVolumeExpansion: true` PVCs grow on TrueNAS (the ZVOL `volsize` updates) but the filesystem on top stays at the old size — `resize2fs`/`xfs_growfs` aren't available. The PVC advertises the new capacity but `df` inside the consumer pod doesn't change.

Issue #25 has the full reproduction + the `apk info -L e2fsprogs | grep resize` proof that resize2fs isn't in the base package on Alpine 3.19.

## Verification

Tested in two ways:

**Clean alpine:3.19 container, apk add only:**

```
$ docker run --rm alpine:3.19 sh -c 'apk add --no-cache ca-certificates nfs-utils \
    open-iscsi e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra util-linux >/dev/null
  for B in resize2fs xfs_growfs mkfs.ext4 mkfs.xfs mount.nfs iscsiadm; do
    printf "  %-15s %s\n" "$B" "$(which $B 2>/dev/null || echo MISSING)"
  done'
  resize2fs       /usr/sbin/resize2fs
  xfs_growfs      /usr/sbin/xfs_growfs
  mkfs.ext4       /sbin/mkfs.ext4
  mkfs.xfs        /sbin/mkfs.xfs
  mount.nfs       /sbin/mount.nfs
  iscsiadm        /usr/sbin/iscsiadm
```

**Full `docker build` of this branch's Dockerfile**, then inspecting the built image — same six binaries present. Driver binary unchanged at ~19.5 MB; image's `apk` layer grows by ~3 MB.

**End-to-end against a real K3s cluster** (verified downstream — I shipped the same fix as a `postStart` workaround in [liskl/homelab#334](https://github.com/liskl/homelab/pull/334) and confirmed: fresh iSCSI PVC mounts on first attempt with zero `FailedMount` events, and `kubectl patch pvc <name> -p '{\"spec\":{\"resources\":{\"requests\":{\"storage\":\"2Gi\"}}}}'` against a 1 Gi PVC grew the ZVOL on TrueNAS AND grew the ext4 inside the running consumer pod from 973 M to 1.9 G without restart, in about 50 s).

## Not changed

- `Dockerfile.ubi` is unaffected. RHEL/CentOS ships the resize tools inside the base `e2fsprogs`/`xfsprogs` packages, and the UBI Dockerfile already explicitly `COPY`-s `/usr/sbin/resize2fs` and `/usr/sbin/xfs_growfs` from its `packages` stage. No edits needed there.
- No code changes in `pkg/` or `cmd/`. This is a single-file, single-line fix to the Alpine image.