### PR TITLE
fix UBI image: stage all nvme-cli shared libs

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -29,12 +29,15 @@ RUN dnf install -y --setopt=install_weak_deps=False \
     xfsprogs \
     && dnf clean all
 
-# Stage the nvme binary and its non-core shared libraries (all live in /usr/lib64:
-# libnvme, libjson-c, and the crypto libs DH-CHAP needs) so we don't have to
-# enumerate each by hand. Core libs (/lib64 glibc, ld) are intentionally excluded.
+# Stage the nvme binary and its shared libraries (libnvme, libjson-c, crypto, ...)
+# without enumerating each by hand. ldd may report libs under /lib64 or /usr/lib64
+# (the former is a symlink to the latter), so copy all resolved deps except the
+# glibc core that ubi-minimal already provides, into /usr/lib64.
 RUN mkdir -p /nvme-deps/usr/lib64 \
     && cp -L /usr/sbin/nvme /nvme-deps/nvme \
-    && ldd /usr/sbin/nvme | awk '/=> \/usr\/lib64/{print $3}' | xargs -I{} cp -L {} /nvme-deps/usr/lib64/
+    && ldd /usr/sbin/nvme | awk '/=>/ {print $3}' \
+       | grep -vE '/(ld-linux-x86-64|libc|libm|libmvec|libpthread|libdl|librt|libresolv|libanl)\.so' \
+       | xargs -I{} cp -L {} /nvme-deps/usr/lib64/
 
 # Stage 3: Final UBI-based image for Red Hat certification
 FROM registry.access.redhat.com/ubi10/ubi-minimal:latest


### PR DESCRIPTION
The NVMe-oF UBI build staged only libs reported by `ldd` under `/usr/lib64`, but `libnvme.so.1` (and others) resolve via `/lib64` (a symlink to `/usr/lib64`), so they were missed — `nvme` failed with `libnvme.so.1: cannot open shared object file`. Now copies all resolved deps except the glibc core that ubi-minimal already provides.

Validated with `make build-ubi`: `nvme version` runs cleanly (2.16 / libnvme 1.16.1) in the image.