### PR TITLE
Bump version to 1.1.1

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -46,7 +46,7 @@ FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 # Required Red Hat certification labels
 LABEL name="truenas-csi" \
       vendor="TrueNAS" \
-      version="1.1.0" \
+      version="1.1.1" \
       release="1" \
       summary="TrueNAS CSI Driver for Kubernetes/OpenShift" \
       description="Container Storage Interface driver for TrueNAS storage systems. Supports NFS, iSCSI, and NVMe-oF protocols with snapshots, clones, and volume expansion." \

--- a/operator/Dockerfile.ubi
+++ b/operator/Dockerfile.ubi
@@ -26,7 +26,7 @@ FROM registry.access.redhat.com/ubi10/ubi-micro:latest
 # Required Red Hat certification labels
 LABEL name="truenas-csi-operator" \
       vendor="TrueNAS" \
-      version="1.1.0" \
+      version="1.1.1" \
       release="1" \
       summary="TrueNAS CSI Operator for Kubernetes/OpenShift" \
       description="Kubernetes operator for deploying and managing the TrueNAS CSI driver on OpenShift. Automates deployment of CSI controller and node components." \

--- a/operator/config/manifests/bases/operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Storage
-    containerImage: quay.io/truenas_solutions/truenas-csi-operator:v1.1.0
+    containerImage: quay.io/truenas_solutions/truenas-csi-operator:v1.1.1
     createdAt: "2026-01-20T00:00:00Z"
     description: Deploys and manages the TrueNAS CSI driver for dynamic volume provisioning
     features.operators.openshift.io/cnf: "false"


### PR DESCRIPTION
Bumps image version labels and the operator CSV containerImage to 1.1.1 for the v1.1.1 release (CVE-patched images).