### PR TITLE
Bump Alpine builder to Go 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.5-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 WORKDIR /build
 COPY go.mod go.sum* ./


### PR DESCRIPTION
go.mod requires go >= 1.25.0 (from the dep bumps), but the Alpine Dockerfile builder was golang:1.24.5-alpine with GOTOOLCHAIN=local, breaking the GHCR build. Bumps it to golang:1.25-alpine.