### PR TITLE
feat: add Helm chart and OCI chart publishing workflow

### DIFF
--- a/.github/workflows/release-ghcr.yaml
+++ b/.github/workflows/release-ghcr.yaml
@@ -1,26 +1,110 @@
-name: Release to GHCR
+name: Release
 
 on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to publish, for example v1.1.1
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
 
 env:
+  CHART_DIR: deploy/helm/truenas-csi
   IMAGE_NAME: ghcr.io/${{ github.repository }}
 
 jobs:
-  build-and-push:
+  metadata:
+    name: Resolve and validate release metadata
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
+    outputs:
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      chart_name: ${{ steps.meta.outputs.chart_name }}
+      chart_version: ${{ steps.meta.outputs.chart_version }}
+      chart_registry: ${{ steps.meta.outputs.chart_registry }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.release_tag || github.ref }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Resolve metadata
+        id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            tag="${{ github.event.inputs.release_tag }}"
+          else
+            tag="${GITHUB_REF#refs/tags/}"
+          fi
+
+          case "$tag" in
+            v*) ;;
+            *)
+              echo "Release tag must start with 'v' (got: $tag)"
+              exit 1
+              ;;
+          esac
+
+          chart_name=$(helm show chart "${CHART_DIR}" | awk '/^name: / {print $2}')
+          chart_version="${tag#v}"
+          owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+
+          echo "release_tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "chart_name=${chart_name}" >> "$GITHUB_OUTPUT"
+          echo "chart_version=${chart_version}" >> "$GITHUB_OUTPUT"
+          echo "chart_registry=ghcr.io/${owner}/charts" >> "$GITHUB_OUTPUT"
+
+      - name: Validate chart placeholder versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          chart_version=$(helm show chart "${CHART_DIR}" | awk '/^version: / {print $2}')
+          chart_app_version=$(helm show chart "${CHART_DIR}" | awk '/^appVersion: / {print $2}' | tr -d '"')
+
+          if [ "$chart_version" != "0.0.0" ]; then
+            echo "Chart.yaml version must remain 0.0.0 (got: $chart_version)"
+            exit 1
+          fi
+
+          if [ "$chart_app_version" != "0.0.0" ]; then
+            echo "Chart.yaml appVersion must remain 0.0.0 (got: $chart_app_version)"
+            exit 1
+          fi
+
+      - name: Helm lint
+        run: helm lint "${CHART_DIR}" --set secret.apiKey=dummy
+
+  image:
+    name: Build and publish container image (${{ matrix.arch }})
+    needs: metadata
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.metadata.outputs.release_tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -32,18 +116,81 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract version from tag
-        id: version
-        run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push
+      - name: Build and push platform image
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
           build-args: |
-            VERSION=${{ steps.version.outputs.tag }}
+            VERSION=${{ needs.metadata.outputs.release_tag }}
           tags: |
-            ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.tag }}
-            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ needs.metadata.outputs.release_tag }}-${{ matrix.arch }}
+
+  image-manifest:
+    name: Publish multi-arch image manifest
+    needs:
+      - metadata
+      - image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifests
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker buildx imagetools create \
+            -t "${IMAGE_NAME}:${{ needs.metadata.outputs.release_tag }}" \
+            -t "${IMAGE_NAME}:latest" \
+            "${IMAGE_NAME}:${{ needs.metadata.outputs.release_tag }}-amd64" \
+            "${IMAGE_NAME}:${{ needs.metadata.outputs.release_tag }}-arm64"
+
+  chart:
+    name: Package and publish Helm chart
+    needs: metadata
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.metadata.outputs.release_tag }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR
+        shell: bash
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Package chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .cr-release-packages
+          helm package "${CHART_DIR}" \
+            --version "${{ needs.metadata.outputs.chart_version }}" \
+            --app-version "${{ needs.metadata.outputs.release_tag }}" \
+            --destination .cr-release-packages
+
+      - name: Push chart
+        shell: bash
+        run: |
+          set -euo pipefail
+          package=".cr-release-packages/${{ needs.metadata.outputs.chart_name }}-${{ needs.metadata.outputs.chart_version }}.tgz"
+          helm push "$package" "oci://${{ needs.metadata.outputs.chart_registry }}"
+
+      - name: Show published references
+        shell: bash
+        run: |
+          echo "Image: ${{ env.IMAGE_NAME }}:${{ needs.metadata.outputs.release_tag }}"
+          echo "Chart: oci://${{ needs.metadata.outputs.chart_registry }}/${{ needs.metadata.outputs.chart_name }}:${{ needs.metadata.outputs.chart_version }}"

--- a/deploy/helm/truenas-csi/.helmignore
+++ b/deploy/helm/truenas-csi/.helmignore
@@ -1,0 +1,8 @@
+.DS_Store
+.git/
+.gitignore
+.github/
+*.swp
+*.bak
+*.tmp
+*.orig

--- a/deploy/helm/truenas-csi/Chart.yaml
+++ b/deploy/helm/truenas-csi/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: truenas-csi
+description: Helm chart for deploying the TrueNAS CSI driver
+home: https://github.com/truenas/truenas-csi
+type: application
+# version + appVersion are overridden at package time from the release tag.
+version: 0.0.0
+appVersion: "0.0.0"
+kubeVersion: ">=1.26.0-0"
+keywords:
+  - csi
+  - storage
+  - truenas
+  - zfs
+sources:
+  - https://github.com/truenas/truenas-csi
+maintainers:
+  - name: truenas-csi

--- a/deploy/helm/truenas-csi/README.md
+++ b/deploy/helm/truenas-csi/README.md
@@ -1,0 +1,87 @@
+# truenas-csi Helm chart
+
+This chart packages the static `deploy/truenas-csi-driver.yaml` manifest into a configurable Helm release.
+
+## Install
+
+```bash
+helm upgrade --install truenas-csi ./deploy/helm/truenas-csi \
+  --namespace truenas-csi \
+  --create-namespace \
+  --set config.truenasURL=wss://truenas.example.com/api/current \
+  --set config.defaultPool=SSD \
+  --set secret.apiKey=REDACTED
+```
+
+## Existing secret
+
+If you already manage credentials externally, set:
+
+- `secret.existingSecret.name`
+- `secret.existingSecret.key`
+
+Example:
+
+```bash
+helm upgrade --install truenas-csi ./deploy/helm/truenas-csi \
+  --namespace truenas-csi \
+  --create-namespace \
+  --set secret.existingSecret.name=truenas-api-credentials
+```
+
+The chart reads `TRUENAS_API_KEY` from the external secret using `secret.existingSecret.name` and `secret.existingSecret.key`.
+
+## Nested dataset placement
+
+Prefer configuring nested dataset placement in StorageClasses via `datasetPath`, for example:
+
+```yaml
+storageClasses:
+  - name: truenas-iscsi
+    parameters:
+      protocol: iscsi
+      pool: SSD
+      datasetPath: talos/volumes
+      fsType: ext4
+```
+
+## Non-standard kubelet roots and iSCSI paths
+
+For Talos, K3s, or MicroK8s-style kubelet layouts, override:
+
+- `node.kubeletRootDir`
+
+The chart derives the plugin and registration paths from that root.
+
+For iSCSI nodes, the chart also exposes:
+
+- `node.iscsiDir`
+
+`node.iscsiDir` defaults to `/etc/iscsi`, which matches the upstream manifest. On Talos, you will typically want `/var/iscsi` instead.
+
+If the host `iscsiadm` binary is not at `/usr/sbin/iscsiadm`, set `ISCSIADM_HOST_PATH` through `node.extraEnv`. For Talos, that will typically be `/usr/local/sbin/iscsiadm`.
+
+
+
+## Required and optional chart values
+
+From the driver source, these `config` values are required:
+
+- `config.truenasURL`
+- `config.defaultPool`
+
+And this secret value is required unless you use an external secret:
+
+- `secret.apiKey`
+
+The chart will fail to render unless either `secret.apiKey` is set or `secret.existingSecret.name` points at an existing Secret.
+
+These `config` values are optional:
+
+- `config.nfsServer`
+- `config.iscsiPortal`
+- `config.nvmeofPortal`
+- `config.iscsiIQNBase`
+- `config.truenasInsecure`
+
+That means you can leave `config.nfsServer`, `config.iscsiPortal`, and `config.nvmeofPortal` empty unless you need to force those values. The driver derives NFS/iSCSI defaults from the TrueNAS URL when possible, and only requires the protocol-specific portal when you actually use that protocol.

--- a/deploy/helm/truenas-csi/templates/NOTES.txt
+++ b/deploy/helm/truenas-csi/templates/NOTES.txt
@@ -1,0 +1,18 @@
+TrueNAS CSI has been deployed.
+
+Namespace: {{ .Release.Namespace }}
+Driver:    {{ include "truenas-csi.driverName" . }}
+Image:     {{ .Values.image.repository }}:{{ .Values.image.tag }}
+
+Check rollout status:
+  kubectl get pods -n {{ .Release.Namespace }}
+  kubectl get csidriver {{ include "truenas-csi.driverName" . }}
+
+If you enabled chart-managed classes:
+  kubectl get storageclass
+  kubectl get volumesnapshotclass
+
+Important:
+- Ensure your worker nodes have the required host paths and mount propagation support.
+- For non-standard kubelet roots (Talos, K3s, MicroK8s), override .Values.node.kubeletRootDir.
+- Prefer setting nested volume placement via StorageClass parameter datasetPath rather than embedding a dataset path into pool.

--- a/deploy/helm/truenas-csi/templates/_helpers.tpl
+++ b/deploy/helm/truenas-csi/templates/_helpers.tpl
@@ -1,0 +1,78 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "truenas-csi.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+Truncated at 63 chars (k8s name limit, DNS-1123).
+*/}}
+{{- define "truenas-csi.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "truenas-csi.labels" -}}
+app.kubernetes.io/name: {{ include "truenas-csi.name" . }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "truenas-csi.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "truenas-csi.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "truenas-csi.driverName" -}}
+csi.truenas.io
+{{- end -}}
+
+{{- define "truenas-csi.controllerServiceAccountName" -}}
+{{- if .Values.serviceAccount.controller.name -}}
+{{- .Values.serviceAccount.controller.name -}}
+{{- else -}}
+{{- printf "%s-controller" (include "truenas-csi.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "truenas-csi.nodeServiceAccountName" -}}
+{{- if .Values.serviceAccount.node.name -}}
+{{- .Values.serviceAccount.node.name -}}
+{{- else -}}
+{{- printf "%s-node" (include "truenas-csi.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "truenas-csi.secretName" -}}
+{{- if .Values.secret.existingSecret.name -}}
+{{- .Values.secret.existingSecret.name -}}
+{{- else if .Values.secret.name -}}
+{{- .Values.secret.name -}}
+{{- else -}}
+{{- printf "%s-credentials" (include "truenas-csi.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "truenas-csi.secretKey" -}}
+{{- if .Values.secret.existingSecret.name -}}
+{{- default "TRUENAS_API_KEY" .Values.secret.existingSecret.key -}}
+{{- else -}}
+TRUENAS_API_KEY
+{{- end -}}
+{{- end -}}
+
+{{- define "truenas-csi.configMapName" -}}
+{{- printf "%s-config" (include "truenas-csi.fullname" .) -}}
+{{- end -}}

--- a/deploy/helm/truenas-csi/templates/clusterrolebindings.yaml
+++ b/deploy/helm/truenas-csi/templates/clusterrolebindings.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-controller
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "truenas-csi.controllerServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "truenas-csi.fullname" . }}-controller
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-node
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "truenas-csi.nodeServiceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "truenas-csi.fullname" . }}-node
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deploy/helm/truenas-csi/templates/clusterroles.yaml
+++ b/deploy/helm/truenas-csi/templates/clusterroles.yaml
@@ -1,0 +1,74 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-controller
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-node
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/deploy/helm/truenas-csi/templates/configmap.yaml
+++ b/deploy/helm/truenas-csi/templates/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "truenas-csi.configMapName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+data:
+  TRUENAS_URL: {{ .Values.config.truenasURL | quote }}
+  TRUENAS_INSECURE_SKIP_VERIFY: {{ .Values.config.truenasInsecure | quote }}
+  TRUENAS_DEFAULT_POOL: {{ .Values.config.defaultPool | quote }}
+  {{- if .Values.config.nfsServer }}
+  TRUENAS_NFS_SERVER: {{ .Values.config.nfsServer | quote }}
+  {{- end }}
+  {{- if .Values.config.iscsiPortal }}
+  TRUENAS_ISCSI_PORTAL: {{ .Values.config.iscsiPortal | quote }}
+  {{- end }}
+  {{- if .Values.config.nvmeofPortal }}
+  TRUENAS_NVMEOF_PORTAL: {{ .Values.config.nvmeofPortal | quote }}
+  {{- end }}
+  {{- if .Values.config.iscsiIQNBase }}
+  TRUENAS_ISCSI_IQN_BASE: {{ .Values.config.iscsiIQNBase | quote }}
+  {{- end }}

--- a/deploy/helm/truenas-csi/templates/controller-deployment.yaml
+++ b/deploy/helm/truenas-csi/templates/controller-deployment.yaml
@@ -92,7 +92,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-provisioner
-          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1
+          image: {{ printf "%s:%s" .Values.sidecars.provisioner.repository .Values.sidecars.provisioner.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -109,7 +109,7 @@ spec:
               mountPath: /csi
 
         - name: csi-attacher
-          image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
+          image: {{ printf "%s:%s" .Values.sidecars.attacher.repository .Values.sidecars.attacher.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -123,7 +123,7 @@ spec:
               mountPath: /csi
 
         - name: csi-snapshotter
-          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
+          image: {{ printf "%s:%s" .Values.sidecars.snapshotter.repository .Values.sidecars.snapshotter.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -137,7 +137,7 @@ spec:
               mountPath: /csi
 
         - name: csi-resizer
-          image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
+          image: {{ printf "%s:%s" .Values.sidecars.resizer.repository .Values.sidecars.resizer.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --v=5
@@ -151,7 +151,7 @@ spec:
               mountPath: /csi
 
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
+          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.repository .Values.sidecars.livenessProbe.tag }}
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9808

--- a/deploy/helm/truenas-csi/templates/controller-deployment.yaml
+++ b/deploy/helm/truenas-csi/templates/controller-deployment.yaml
@@ -1,0 +1,167 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+spec:
+  replicas: {{ .Values.controller.replicas }}
+  selector:
+    matchLabels:
+      {{- include "truenas-csi.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: controller
+
+  template:
+    metadata:
+      labels:
+        {{- include "truenas-csi.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: controller
+        {{- with .Values.controller.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ toYaml .Values.config | sha256sum }}
+        checksum/secret: {{ toYaml .Values.secret | sha256sum }}
+        {{- with .Values.controller.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "truenas-csi.controllerServiceAccountName" . }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: csi-controller
+          image: {{ printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --node-id=$(NODE_ID)
+            - --mode=controller
+            - --v={{ .Values.controller.logLevel }}
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TRUENAS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "truenas-csi.secretName" . }}
+                  key: {{ include "truenas-csi.secretKey" . }}
+            {{- with .Values.controller.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "truenas-csi.configMapName" . }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            {{- with .Values.controller.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.controller.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9808
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
+        - name: csi-provisioner
+          image: registry.k8s.io/sig-storage/csi-provisioner:v6.1.1
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+            - --feature-gates=Topology=true
+            - --extra-create-metadata
+            - --leader-election=true
+            - --default-fstype=ext4
+            - --timeout=60s
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+
+        - name: csi-attacher
+          image: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+            - --leader-election=true
+            - --timeout=60s
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+
+        - name: csi-snapshotter
+          image: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+            - --leader-election=true
+            - --timeout=60s
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+
+        - name: csi-resizer
+          image: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
+          args:
+            - --csi-address=$(ADDRESS)
+            - --v=5
+            - --leader-election=true
+            - --timeout=60s
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9808
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        {{- with .Values.controller.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deploy/helm/truenas-csi/templates/csidriver.yaml
+++ b/deploy/helm/truenas-csi/templates/csidriver.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: CSIDriver
+metadata:
+  name: {{ include "truenas-csi.driverName" . }}
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+spec:
+  attachRequired: true
+  podInfoOnMount: true
+  fsGroupPolicy: File
+  volumeLifecycleModes:
+    - Persistent
+    - Ephemeral

--- a/deploy/helm/truenas-csi/templates/node-daemonset.yaml
+++ b/deploy/helm/truenas-csi/templates/node-daemonset.yaml
@@ -1,0 +1,189 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-node
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node
+spec:
+  selector:
+    matchLabels:
+      {{- include "truenas-csi.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: node
+
+  template:
+    metadata:
+      labels:
+        {{- include "truenas-csi.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: node
+        {{- with .Values.node.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ toYaml .Values.config | sha256sum }}
+        checksum/secret: {{ toYaml .Values.secret | sha256sum }}
+        {{- with .Values.node.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ include "truenas-csi.nodeServiceAccountName" . }}
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- with .Values.node.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.node.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: csi-node
+          image: {{ printf "%s:%s" .Values.image.repository (default .Chart.AppVersion .Values.image.tag) }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    set -e
+                    mkdir -p /run/lock/iscsi
+                    mv /usr/sbin/iscsiadm /usr/sbin/iscsiadm.orig 2>/dev/null || true
+                    printf '#!/bin/sh\nnsenter --mount=/host/proc/1/ns/mnt -- "${ISCSIADM_HOST_PATH:-/usr/sbin/iscsiadm}" "$@"\n' > /usr/sbin/iscsiadm
+                    chmod +x /usr/sbin/iscsiadm
+                    modprobe nvme_tcp 2>/dev/null
+                    modprobe nvme_fabrics 2>/dev/null
+          securityContext:
+            privileged: true
+          args:
+            - --endpoint=$(CSI_ENDPOINT)
+            - --node-id=$(NODE_ID)
+            - --mode=node
+            - --v={{ .Values.node.logLevel }}
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: NODE_ID
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: TRUENAS_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "truenas-csi.secretName" . }}
+                  key: {{ include "truenas-csi.secretKey" . }}
+            {{- with .Values.node.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "truenas-csi.configMapName" . }}
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: kubelet-dir
+              mountPath: {{ .Values.node.kubeletRootDir }}
+              mountPropagation: Bidirectional
+            - name: device-dir
+              mountPath: /dev
+            - name: modules-dir
+              mountPath: /lib/modules
+              readOnly: true
+            - name: iscsi-dir
+              mountPath: {{ .Values.node.iscsiDir }}
+              mountPropagation: Bidirectional
+            - name: iscsi-lib
+              mountPath: /var/lib/iscsi
+              mountPropagation: Bidirectional
+            - name: host-root
+              mountPath: /host
+              mountPropagation: Bidirectional
+            {{- with .Values.node.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.node.resources | nindent 12 }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9808
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+            failureThreshold: 5
+        - name: csi-node-driver-registrar
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
+          args:
+            - --csi-address=$(ADDRESS)
+            - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
+            - --v=5
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: {{ printf "%s/plugins/%s/csi.sock" .Values.node.kubeletRootDir (include "truenas-csi.driverName" .) }}
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: registration-dir
+              mountPath: /registration
+
+        - name: liveness-probe
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
+          args:
+            - --csi-address=/csi/csi.sock
+            - --health-port=9808
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: {{ printf "%s/plugins_registry" .Values.node.kubeletRootDir }}
+            type: DirectoryOrCreate
+        - name: plugin-dir
+          hostPath:
+            path: {{ printf "%s/plugins/%s" .Values.node.kubeletRootDir (include "truenas-csi.driverName" .) }}
+            type: DirectoryOrCreate
+        - name: kubelet-dir
+          hostPath:
+            path: {{ .Values.node.kubeletRootDir }}
+            type: Directory
+        - name: device-dir
+          hostPath:
+            path: /dev
+        - name: modules-dir
+          hostPath:
+            path: /lib/modules
+            type: Directory
+        - name: iscsi-dir
+          hostPath:
+            path: {{ .Values.node.iscsiDir }}
+            type: DirectoryOrCreate
+        - name: iscsi-lib
+          hostPath:
+            path: /var/lib/iscsi
+            type: DirectoryOrCreate
+        - name: host-root
+          hostPath:
+            path: /
+            type: Directory
+        {{- with .Values.node.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/deploy/helm/truenas-csi/templates/node-daemonset.yaml
+++ b/deploy/helm/truenas-csi/templates/node-daemonset.yaml
@@ -127,7 +127,7 @@ spec:
             periodSeconds: 10
             failureThreshold: 5
         - name: csi-node-driver-registrar
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
+          image: {{ printf "%s:%s" .Values.sidecars.nodeDriverRegistrar.repository .Values.sidecars.nodeDriverRegistrar.tag }}
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -144,7 +144,7 @@ spec:
               mountPath: /registration
 
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
+          image: {{ printf "%s:%s" .Values.sidecars.livenessProbe.repository .Values.sidecars.livenessProbe.tag }}
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9808
@@ -170,7 +170,7 @@ spec:
             path: /dev
         - name: modules-dir
           hostPath:
-            path: /lib/modules
+            path: {{ .Values.config.kernelModulesHostPath }}
             type: Directory
         - name: iscsi-dir
           hostPath:

--- a/deploy/helm/truenas-csi/templates/openshift-capabilities.yaml
+++ b/deploy/helm/truenas-csi/templates/openshift-capabilities.yaml
@@ -1,0 +1,56 @@
+{{- if .Values.openshift.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-capabilities
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: certification
+data:
+  driver-name: {{ include "truenas-csi.driverName" . | quote }}
+  driver-version: {{ .Chart.AppVersion | quote }}
+  csi-version: "1.8.0"
+  protocols: |
+    - nfs
+    - iscsi
+    - nvmeof
+  controller-capabilities: |
+    - CREATE_DELETE_VOLUME
+    - CREATE_DELETE_SNAPSHOT
+    - CLONE_VOLUME
+    - EXPAND_VOLUME
+    - LIST_VOLUMES
+    - GET_CAPACITY
+  node-capabilities: |
+    - STAGE_UNSTAGE_VOLUME
+    - GET_VOLUME_STATS
+    - EXPAND_VOLUME
+  volume-capabilities: |
+    - accessModes:
+        - ReadWriteOnce
+        - ReadOnlyMany
+        - ReadWriteMany
+      fsTypes:
+        - nfs
+        - nfs4
+    - accessModes:
+        - ReadWriteOnce
+        - ReadOnlyMany
+      fsTypes:
+        - ext4
+        - xfs
+      blockVolume: true
+  snapshot-capabilities: |
+    - CREATE_DELETE_SNAPSHOT
+  features: |
+    - dynamic-provisioning
+    - volume-expansion
+    - volume-snapshots
+    - volume-cloning
+    - raw-block-volumes
+    - fsgroup-policy
+  unsupported-features: |
+    - volume-topology
+    - volume-health-monitoring
+{{- end }}

--- a/deploy/helm/truenas-csi/templates/openshift-scc.yaml
+++ b/deploy/helm/truenas-csi/templates/openshift-scc.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.openshift.enabled }}
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-node
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: node
+allowPrivilegedContainer: true
+allowHostIPC: true
+allowHostNetwork: true
+allowHostPID: true
+allowHostPorts: true
+allowHostDirVolumePlugin: true
+allowedCapabilities:
+  - SYS_ADMIN
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - persistentVolumeClaim
+  - projected
+  - secret
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "truenas-csi.nodeServiceAccountName" . }}
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "truenas-csi.fullname" . }}-controller
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+    app.kubernetes.io/component: controller
+allowPrivilegedContainer: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowHostDirVolumePlugin: false
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - projected
+  - secret
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ include "truenas-csi.controllerServiceAccountName" . }}
+{{- end }}

--- a/deploy/helm/truenas-csi/templates/secret.yaml
+++ b/deploy/helm/truenas-csi/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.secret.existingSecret.name }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "truenas-csi.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  TRUENAS_API_KEY: {{ .Values.secret.apiKey | quote }}
+{{- end }}

--- a/deploy/helm/truenas-csi/templates/serviceaccounts.yaml
+++ b/deploy/helm/truenas-csi/templates/serviceaccounts.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.serviceAccount.controller.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "truenas-csi.controllerServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.controller.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.serviceAccount.node.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "truenas-csi.nodeServiceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "truenas-csi.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.node.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/truenas-csi/templates/storageclasses.yaml
+++ b/deploy/helm/truenas-csi/templates/storageclasses.yaml
@@ -1,0 +1,26 @@
+{{- range .Values.storageClasses }}
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .name }}
+  {{- if or .annotations .defaultClass }}
+  annotations:
+    {{- if .defaultClass }}
+    storageclass.kubernetes.io/is-default-class: "true"
+    {{- end }}
+    {{- with .annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+provisioner: {{ include "truenas-csi.driverName" $ }}
+reclaimPolicy: {{ default "Delete" .reclaimPolicy }}
+volumeBindingMode: {{ default "WaitForFirstConsumer" .volumeBindingMode }}
+allowVolumeExpansion: {{ default true .allowVolumeExpansion }}
+{{- with .mountOptions }}
+mountOptions:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+parameters:
+  {{- toYaml .parameters | nindent 2 }}
+{{- end }}

--- a/deploy/helm/truenas-csi/templates/volumesnapshotclasses.yaml
+++ b/deploy/helm/truenas-csi/templates/volumesnapshotclasses.yaml
@@ -1,0 +1,17 @@
+{{- range .Values.volumeSnapshotClasses }}
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotClass
+metadata:
+  name: {{ .name }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+driver: {{ include "truenas-csi.driverName" $ }}
+deletionPolicy: {{ default "Delete" .deletionPolicy }}
+{{- with .parameters }}
+parameters:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/truenas-csi/values.schema.json
+++ b/deploy/helm/truenas-csi/values.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
+    "image": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string" },
+        "pullPolicy": { "type": "string", "enum": ["Always", "IfNotPresent", "Never"] },
+        "pullSecrets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "properties": {
+              "name": { "type": "string" }
+            }
+          }
+        }
+      },
+      "required": ["repository", "tag", "pullPolicy", "pullSecrets"]
+    },
+    "config": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "truenasURL": { "type": "string", "pattern": "^wss?://" },
+        "truenasInsecure": { "type": "boolean" },
+        "defaultPool": { "type": "string", "minLength": 1 },
+        "nfsServer": { "type": "string" },
+        "iscsiPortal": { "type": "string" },
+        "nvmeofPortal": { "type": "string" },
+        "iscsiIQNBase": { "type": "string" }
+      },
+      "required": ["truenasURL", "truenasInsecure", "defaultPool", "nfsServer", "iscsiPortal", "nvmeofPortal", "iscsiIQNBase"]
+    },
+    "secret": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "existingSecret": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "name": { "type": "string" },
+            "key": { "type": "string", "minLength": 1 }
+          },
+          "required": ["name", "key"]
+        },
+        "name": { "type": "string", "minLength": 1 },
+        "apiKey": { "type": "string" }
+      },
+      "required": ["existingSecret", "name", "apiKey"]
+    },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "controller": { "$ref": "#/definitions/serviceAccountSpec" },
+        "node": { "$ref": "#/definitions/serviceAccountSpec" }
+      },
+      "required": ["controller", "node"]
+    },
+    "rbac": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" }
+      },
+      "required": ["create"]
+    },
+    "controller": { "$ref": "#/definitions/controllerSpec" },
+    "node": { "$ref": "#/definitions/nodeSpec" },
+    "storageClasses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+          "defaultClass": { "type": "boolean" },
+          "reclaimPolicy": { "type": "string" },
+          "volumeBindingMode": { "type": "string" },
+          "allowVolumeExpansion": { "type": "boolean" },
+          "mountOptions": { "type": "array", "items": { "type": "string" } },
+          "parameters": { "type": "object", "additionalProperties": { "type": ["string", "number", "boolean"] } }
+        },
+        "required": ["name", "parameters"]
+      }
+    },
+    "volumeSnapshotClasses": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string", "minLength": 1 },
+          "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+          "deletionPolicy": { "type": "string" },
+          "parameters": { "type": "object", "additionalProperties": { "type": ["string", "number", "boolean"] } }
+        },
+        "required": ["name"]
+      }
+    }
+  },
+  "required": ["image", "config", "secret", "serviceAccount", "rbac", "controller", "node", "storageClasses", "volumeSnapshotClasses"],
+  "anyOf": [
+    {
+      "properties": {
+        "secret": {
+          "properties": {
+            "apiKey": { "type": "string", "minLength": 1 }
+          }
+        }
+      }
+    },
+    {
+      "properties": {
+        "secret": {
+          "properties": {
+            "existingSecret": {
+              "properties": {
+                "name": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "definitions": {
+    "serviceAccountSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "create": { "type": "boolean" },
+        "name": { "type": "string" },
+        "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
+      },
+      "required": ["create", "name", "annotations"]
+    },
+    "resources": {
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {
+        "requests": { "type": "object", "additionalProperties": { "type": ["string", "number"] } },
+        "limits": { "type": "object", "additionalProperties": { "type": ["string", "number"] } }
+      }
+    },
+    "controllerSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "replicas": { "type": "integer", "minimum": 1 },
+        "priorityClassName": { "type": "string" },
+        "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "podLabels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
+        "tolerations": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "affinity": { "type": "object", "additionalProperties": true },
+        "resources": { "$ref": "#/definitions/resources" },
+        "logLevel": { "type": "integer", "minimum": 1 },
+        "extraEnv": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "extraVolumeMounts": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "extraVolumes": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "required": ["replicas", "priorityClassName", "podAnnotations", "podLabels", "nodeSelector", "tolerations", "affinity", "resources", "logLevel", "extraEnv", "extraVolumeMounts", "extraVolumes"]
+    },
+    "nodeSpec": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "priorityClassName": { "type": "string" },
+        "podAnnotations": { "type": "object", "additionalProperties": { "type": "string" } },
+        "podLabels": { "type": "object", "additionalProperties": { "type": "string" } },
+        "nodeSelector": { "type": "object", "additionalProperties": { "type": "string" } },
+        "tolerations": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "affinity": { "type": "object", "additionalProperties": true },
+        "resources": { "$ref": "#/definitions/resources" },
+        "logLevel": { "type": "integer", "minimum": 1 },
+        "extraEnv": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "extraVolumeMounts": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "extraVolumes": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "kubeletRootDir": { "type": "string", "minLength": 1 },
+        "iscsiDir": { "type": "string", "minLength": 1 }
+      },
+      "required": ["priorityClassName", "podAnnotations", "podLabels", "nodeSelector", "tolerations", "affinity", "resources", "logLevel", "extraEnv", "extraVolumeMounts", "extraVolumes", "kubeletRootDir", "iscsiDir"]
+    }
+  }
+}

--- a/deploy/helm/truenas-csi/values.schema.json
+++ b/deploy/helm/truenas-csi/values.schema.json
@@ -25,6 +25,19 @@
       },
       "required": ["repository", "tag", "pullPolicy", "pullSecrets"]
     },
+    "sidecars": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provisioner": { "$ref": "#/definitions/imageRef" },
+        "attacher": { "$ref": "#/definitions/imageRef" },
+        "snapshotter": { "$ref": "#/definitions/imageRef" },
+        "resizer": { "$ref": "#/definitions/imageRef" },
+        "nodeDriverRegistrar": { "$ref": "#/definitions/imageRef" },
+        "livenessProbe": { "$ref": "#/definitions/imageRef" }
+      },
+      "required": ["provisioner", "attacher", "snapshotter", "resizer", "nodeDriverRegistrar", "livenessProbe"]
+    },
     "config": {
       "type": "object",
       "additionalProperties": false,
@@ -35,9 +48,10 @@
         "nfsServer": { "type": "string" },
         "iscsiPortal": { "type": "string" },
         "nvmeofPortal": { "type": "string" },
-        "iscsiIQNBase": { "type": "string" }
+        "iscsiIQNBase": { "type": "string" },
+        "kernelModulesHostPath": { "type": "string", "minLength": 1 }
       },
-      "required": ["truenasURL", "truenasInsecure", "defaultPool", "nfsServer", "iscsiPortal", "nvmeofPortal", "iscsiIQNBase"]
+      "required": ["truenasURL", "truenasInsecure", "defaultPool", "nfsServer", "iscsiPortal", "nvmeofPortal", "iscsiIQNBase", "kernelModulesHostPath"]
     },
     "secret": {
       "type": "object",
@@ -74,6 +88,14 @@
       },
       "required": ["create"]
     },
+    "openshift": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" }
+      },
+      "required": ["enabled"]
+    },
     "controller": { "$ref": "#/definitions/controllerSpec" },
     "node": { "$ref": "#/definitions/nodeSpec" },
     "storageClasses": {
@@ -109,7 +131,7 @@
       }
     }
   },
-  "required": ["image", "config", "secret", "serviceAccount", "rbac", "controller", "node", "storageClasses", "volumeSnapshotClasses"],
+  "required": ["image", "sidecars", "config", "secret", "serviceAccount", "rbac", "openshift", "controller", "node", "storageClasses", "volumeSnapshotClasses"],
   "anyOf": [
     {
       "properties": {
@@ -144,6 +166,15 @@
         "annotations": { "type": "object", "additionalProperties": { "type": "string" } }
       },
       "required": ["create", "name", "annotations"]
+    },
+    "imageRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": "string", "minLength": 1 }
+      },
+      "required": ["repository", "tag"]
     },
     "resources": {
       "type": "object",

--- a/deploy/helm/truenas-csi/values.yaml
+++ b/deploy/helm/truenas-csi/values.yaml
@@ -7,6 +7,26 @@ image:
   pullPolicy: IfNotPresent
   pullSecrets: []
 
+sidecars:
+  provisioner:
+    repository: registry.k8s.io/sig-storage/csi-provisioner
+    tag: v6.1.1
+  attacher:
+    repository: registry.k8s.io/sig-storage/csi-attacher
+    tag: v4.11.0
+  snapshotter:
+    repository: registry.k8s.io/sig-storage/csi-snapshotter
+    tag: v8.5.0
+  resizer:
+    repository: registry.k8s.io/sig-storage/csi-resizer
+    tag: v2.1.0
+  nodeDriverRegistrar:
+    repository: registry.k8s.io/sig-storage/csi-node-driver-registrar
+    tag: v2.16.0
+  livenessProbe:
+    repository: registry.k8s.io/sig-storage/livenessprobe
+    tag: v2.18.0
+
 config:
   truenasURL: wss://truenas.example.com/api/current
   truenasInsecure: true
@@ -15,6 +35,7 @@ config:
   iscsiPortal: ""
   nvmeofPortal: ""
   iscsiIQNBase: iqn.2000-01.io.truenas
+  kernelModulesHostPath: /lib/modules
 
 secret:
   existingSecret:
@@ -35,6 +56,9 @@ serviceAccount:
 
 rbac:
   create: true
+
+openshift:
+  enabled: false
 
 controller:
   replicas: 1

--- a/deploy/helm/truenas-csi/values.yaml
+++ b/deploy/helm/truenas-csi/values.yaml
@@ -1,0 +1,101 @@
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/truenas/truenas-csi
+  tag: ""
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+config:
+  truenasURL: wss://truenas.example.com/api/current
+  truenasInsecure: true
+  defaultPool: tank
+  nfsServer: ""
+  iscsiPortal: ""
+  nvmeofPortal: ""
+  iscsiIQNBase: iqn.2000-01.io.truenas
+
+secret:
+  existingSecret:
+    name: ""
+    key: TRUENAS_API_KEY
+  name: truenas-api-credentials
+  apiKey: ""
+
+serviceAccount:
+  controller:
+    create: true
+    name: ""
+    annotations: {}
+  node:
+    create: true
+    name: ""
+    annotations: {}
+
+rbac:
+  create: true
+
+controller:
+  replicas: 1
+  priorityClassName: ""
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 200m
+  logLevel: 4
+  extraEnv: []
+  extraVolumeMounts: []
+  extraVolumes: []
+
+node:
+  priorityClassName: system-node-critical
+  podAnnotations: {}
+  podLabels: {}
+  nodeSelector: {}
+  tolerations:
+    - operator: Exists
+  affinity: {}
+  resources:
+    requests:
+      memory: 128Mi
+      cpu: 100m
+    limits:
+      memory: 256Mi
+      cpu: 200m
+  logLevel: 4
+  extraEnv: []
+  extraVolumeMounts: []
+  extraVolumes: []
+  kubeletRootDir: /var/lib/kubelet
+  iscsiDir: /etc/iscsi
+
+storageClasses: []
+#  - name: truenas-iscsi
+#    annotations: {}
+#    defaultClass: false
+#    reclaimPolicy: Delete
+#    volumeBindingMode: WaitForFirstConsumer
+#    allowVolumeExpansion: true
+#    mountOptions: []
+#    parameters:
+#      protocol: iscsi
+#      pool: tank
+#      datasetPath: talos/volumes
+#      fsType: ext4
+#      compression: lz4
+#      volblocksize: 16K
+
+volumeSnapshotClasses: []
+#  - name: truenas
+#    annotations: {}
+#    deletionPolicy: Delete
+#    parameters: {}


### PR DESCRIPTION
## Summary

This adds a Helm chart for `truenas-csi` under `deploy/helm/truenas-csi` and extends the existing release workflow to publish the chart as an OCI artifact alongside the driver image.

Resolves #22.

## What this includes

- Helm chart for the static manifest deployment
- controller + node workloads
- RBAC, service accounts, `CSIDriver`, config `ConfigMap`, and API-key `Secret` handling
- optional `StorageClass` and `VolumeSnapshotClass` creation
- `values.schema.json` for chart-side validation
- configurable CSI sidecar image `repository` / `tag` values
- configurable kernel-modules host path for the node plugin
- OpenShift compatibility resources behind a chart toggle
- OCI chart publishing from the existing GitHub Actions release flow
- native multi-arch image builds using separate amd64 and arm64 GitHub runners instead of QEMU-based emulation
- release-time chart version stamping so chart version tracks the driver release version

## Why this version

There is already an open proposal in #24. This PR takes a slightly different approach:

- it keeps the chart fairly opinionated rather than making every manifest detail user-tunable
- it still exposes the knobs that turned out to matter in practice, especially for Talos-based clusters
- it includes publishing workflow wiring for the chart OCI artifact instead of only adding chart sources to the repo
- it includes the OpenShift compatibility pieces requested in review without making the CSI driver name itself configurable

## Talos / real-cluster validation

This chart was test-driven against a live Talos Kubernetes cluster backed by TrueNAS, covering:

- NFS provisioning and mount
- iSCSI provisioning and mount
- NVMe-oF provisioning and mount
- snapshot + restore validation for NFS and iSCSI

A few chart decisions came directly out of that validation, for example:

- configurable kubelet root dir
- configurable iSCSI host path directory
- optional host `iscsiadm` path override for Talos (`/usr/local/sbin/iscsiadm`)
- configurable kernel modules host path
- keeping the node-side helper behavior necessary for iSCSI / NVMe-oF attach flows

## OpenShift notes

This PR adds:

- OpenShift SCC templates
- an OpenShift capabilities ConfigMap
- a chart toggle to enable those resources when needed

## Notes

- chart `version` / `appVersion` are intentionally set to placeholder values in git and stamped at package time from the release tag
- the chart defaults to `ghcr.io/truenas/truenas-csi`
- `CSIDriver` creation is unconditional because the deployment is not meaningful without it
- sidecar images are configurable by `repository` / `tag`, but the broader sidecar behavior remains intentionally opinionated

If maintainers prefer, I can also split this into smaller PRs (chart first, workflow follow-up), but I wanted to submit the complete path needed to actually consume the chart as an OCI artifact.
