### PR TITLE
source CHAP, DH-CHAP, and encryption credentials from Secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,20 @@ NVMe-oF also uses the `volblocksize` parameter above. DH-CHAP authentication is 
 | `encryption.key` | Hex-encoded key (64 chars) | string |
 | `encryption.generateKey` | Auto-generate key | `true`, `false` |
 
+#### Credentials from a Secret
+
+Sensitive parameters can be supplied from a Kubernetes Secret instead of inline StorageClass values, keeping them out of the StorageClass and the persisted PersistentVolume. A value from a Secret takes precedence over the matching inline parameter, so existing StorageClasses keep working unchanged.
+
+| Purpose | StorageClass reference | Secret data keys |
+|---------|------------------------|------------------|
+| ZFS encryption key/passphrase | `csi.storage.k8s.io/provisioner-secret-name` / `-namespace` | `encryption.key`, `encryption.passphrase` |
+| iSCSI CHAP auth group (controller) | `csi.storage.k8s.io/provisioner-secret-name` / `-namespace` | `iscsi.chapSecret`, `iscsi.chapPeerSecret` |
+| iSCSI CHAP login (node) | `csi.storage.k8s.io/node-stage-secret-name` / `-namespace` | `iscsi.chapUsername`, `iscsi.chapPassword`, `iscsi.chapUsernameIn`, `iscsi.chapPasswordIn` |
+| NVMe-oF DH-CHAP host registration (controller) | `csi.storage.k8s.io/provisioner-secret-name` / `-namespace` | `nvmeof.dhchapKey`, `nvmeof.dhchapCtrlKey` |
+| NVMe-oF DH-CHAP connection (node) | `csi.storage.k8s.io/node-stage-secret-name` / `-namespace` | `nvmeof.dhchapKey`, `nvmeof.dhchapCtrlKey` |
+
+iSCSI CHAP and NVMe-oF DH-CHAP each use both a provisioner-secret (to configure TrueNAS: the CHAP auth group / the nvmet host) and a node-stage-secret (for the node's login/connection); the same Secret can serve both roles. The controller ServiceAccount is granted `get`/`list`/`watch` on `secrets` so the external-provisioner can resolve the provisioner-secret; node-stage secrets are resolved by kubelet. See `examples/storageclass-iscsi-chap-secret.yaml`, `examples/storageclass-nvmeof-dhchap-secret.yaml`, and `examples/storageclass-encrypted-secret.yaml`.
+
 ## Examples
 
 See the [`examples/`](examples/) folder for sample configurations:
@@ -222,9 +236,12 @@ See the [`examples/`](examples/) folder for sample configurations:
 - `storageclass-nfs-compressed.yaml` - NFS with ZSTD compression
 - `storageclass-iscsi.yaml` - Basic iSCSI StorageClass
 - `storageclass-iscsi-chap.yaml` - iSCSI with CHAP authentication
+- `storageclass-iscsi-chap-secret.yaml` - iSCSI CHAP credentials from a Secret
 - `storageclass-nvmeof.yaml` - Basic NVMe-oF/TCP StorageClass
 - `storageclass-nvmeof-dhchap.yaml` - NVMe-oF with DH-CHAP authentication
+- `storageclass-nvmeof-dhchap-secret.yaml` - NVMe-oF DH-CHAP keys from a Secret
 - `storageclass-encrypted.yaml` - Encrypted storage
+- `storageclass-encrypted-secret.yaml` - Encrypted storage with the key from a Secret
 - `pvc-nfs.yaml` / `pvc-iscsi.yaml` / `pvc-nvmeof.yaml` - PVC examples
 - `pod-with-pvc.yaml` - Pod using a PVC
 - `volumesnapshotclass.yaml` / `volumesnapshot.yaml` - Snapshot examples

--- a/deploy/truenas-csi-driver.yaml
+++ b/deploy/truenas-csi-driver.yaml
@@ -28,6 +28,12 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: truenas-csi-controller-role
 rules:
+  # Required by external-provisioner to resolve the Secret referenced by the
+  # csi.storage.k8s.io/provisioner-secret-* StorageClass parameters (iSCSI CHAP
+  # secret, ZFS encryption key/passphrase).
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/examples/storageclass-encrypted-secret.yaml
+++ b/examples/storageclass-encrypted-secret.yaml
@@ -1,0 +1,40 @@
+# Encrypted StorageClass with the ZFS encryption key sourced from a Secret.
+#
+# The encryption key (or passphrase) is only needed by the controller at
+# provisioning time, so a provisioner-secret is sufficient. The value is read
+# from the csi.storage.k8s.io/provisioner-secret-* Secret and is never written
+# to the PersistentVolume, keeping it out of the StorageClass and etcd.
+#
+# Supported Secret keys: encryption.key (64 hex chars) or encryption.passphrase
+# (min 8 chars). A value supplied via Secret takes precedence over the matching
+# inline parameter.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: truenas-encryption
+  namespace: truenas-csi
+type: Opaque
+stringData:
+  # Hex-encoded 256-bit key (64 characters):
+  encryption.key: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  # Alternative: a passphrase (min 8 characters):
+  # encryption.passphrase: "my-secure-passphrase"
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: truenas-nfs-encrypted
+provisioner: csi.truenas.io
+parameters:
+  protocol: "nfs"
+  compression: "LZ4"
+  # Enable ZFS encryption.
+  encryption: "true"
+  # Encryption algorithm (optional): AES-256-GCM (default), AES-128-CCM, ...
+  # encryption.algorithm: "AES-256-GCM"
+  # The key/passphrase comes from this Secret rather than an inline parameter.
+  csi.storage.k8s.io/provisioner-secret-name: "truenas-encryption"
+  csi.storage.k8s.io/provisioner-secret-namespace: "truenas-csi"
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/examples/storageclass-iscsi-chap-secret.yaml
+++ b/examples/storageclass-iscsi-chap-secret.yaml
@@ -1,0 +1,53 @@
+# iSCSI StorageClass with CHAP authentication sourced from a Kubernetes Secret.
+#
+# CHAP involves two independent credential paths in this driver:
+#   * Controller (provisioning): creates the TrueNAS CHAP auth group. The secret
+#     value is read from the csi.storage.k8s.io/provisioner-secret-* Secret
+#     (key: iscsi.chapSecret), the username stays a plain parameter.
+#   * Node (login): the node plugin logs in to the target. The credentials are
+#     read from the csi.storage.k8s.io/node-stage-secret-* Secret
+#     (keys: iscsi.chapUsername / iscsi.chapPassword).
+#
+# The same Secret can serve both roles, as shown here. Credentials supplied via
+# Secret take precedence over inline parameters and are never written to the
+# PersistentVolume, keeping them out of the StorageClass and etcd.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: truenas-iscsi-chap
+  namespace: truenas-csi
+type: Opaque
+stringData:
+  # Consumed by the controller (provisioner-secret) to build the TrueNAS auth group:
+  iscsi.chapSecret: "chappassword123"      # 12-16 characters
+  # Consumed by the node (node-stage-secret) at iSCSI login:
+  iscsi.chapUsername: "chapuser"
+  iscsi.chapPassword: "chappassword123"
+  # Mutual CHAP (optional):
+  # iscsi.chapPeerSecret: "peerpassword123" # controller (provisioner-secret)
+  # iscsi.chapUsernameIn: "peeruser"        # node (node-stage-secret)
+  # iscsi.chapPasswordIn: "peerpassword123" # node (node-stage-secret)
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: truenas-iscsi-secure
+provisioner: csi.truenas.io
+parameters:
+  protocol: "iscsi"
+  compression: "LZ4"
+  volblocksize: "16K"
+  iscsi.blocksize: "4096"
+  # CHAP username for the TrueNAS auth group (not sensitive; stays inline).
+  iscsi.chapUser: "chapuser"
+  # Mutual CHAP peer username (optional):
+  # iscsi.chapPeerUser: "peeruser"
+  # Secret references. The external-provisioner resolves the provisioner-secret;
+  # kubelet resolves the node-stage-secret at NodeStageVolume.
+  csi.storage.k8s.io/provisioner-secret-name: "truenas-iscsi-chap"
+  csi.storage.k8s.io/provisioner-secret-namespace: "truenas-csi"
+  csi.storage.k8s.io/node-stage-secret-name: "truenas-iscsi-chap"
+  csi.storage.k8s.io/node-stage-secret-namespace: "truenas-csi"
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/examples/storageclass-nvmeof-dhchap-secret.yaml
+++ b/examples/storageclass-nvmeof-dhchap-secret.yaml
@@ -1,0 +1,48 @@
+# NVMe-oF/TCP StorageClass with DH-CHAP keys sourced from a Kubernetes Secret.
+#
+# DH-CHAP keys are used in two places, like iSCSI CHAP:
+#   * Controller (provisioning): registers the nvmet host on TrueNAS with the key.
+#     Sourced from the csi.storage.k8s.io/provisioner-secret-* Secret.
+#   * Node (connection): `nvme connect --dhchap-secret` / `--dhchap-ctrl-secret`.
+#     Sourced from the csi.storage.k8s.io/node-stage-secret-* Secret.
+#
+# The same Secret can serve both roles. Keys from a Secret take precedence over
+# inline parameters and are never written to the PersistentVolume.
+#
+# Generate a DH-CHAP key on any host with nvme-cli:
+#   nvme gen-dhchap-key -n <hostNQN>
+apiVersion: v1
+kind: Secret
+metadata:
+  name: truenas-nvmeof-dhchap
+  namespace: truenas-csi
+type: Opaque
+stringData:
+  nvmeof.dhchapKey: "DHHC-1:00:MTUwz3xtbtfXLMfFi1mtABCDEF1234567890abcdefghij1234:"
+  # Mutual (bidirectional) DH-CHAP (optional):
+  # nvmeof.dhchapCtrlKey: "DHHC-1:00:abcdef1234567890..."
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: truenas-nvmeof-secure
+provisioner: csi.truenas.io
+parameters:
+  protocol: "nvmeof"
+  compression: "LZ4"
+  volblocksize: "16K"
+  # Host NQN authorized to access volumes in this StorageClass (identifier, not
+  # sensitive; stays inline). Required when a DH-CHAP key is set.
+  nvmeof.hostNQN: "nqn.2014-08.org.nvmexpress:uuid:0c468c4d-a385-47e0-8299-6e95aa8b1e3a"
+  # Hash / DH group are algorithm selectors, not secret (optional):
+  # nvmeof.dhchapHash: "SHA-256"
+  # nvmeof.dhchapDHGroup: "2048-BIT"
+  # The DH-CHAP key(s) come from this Secret, referenced for both provisioning
+  # (controller) and connection (node).
+  csi.storage.k8s.io/provisioner-secret-name: "truenas-nvmeof-dhchap"
+  csi.storage.k8s.io/provisioner-secret-namespace: "truenas-csi"
+  csi.storage.k8s.io/node-stage-secret-name: "truenas-nvmeof-dhchap"
+  csi.storage.k8s.io/node-stage-secret-namespace: "truenas-csi"
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -195,7 +195,7 @@ func (s *ControllerServer) validateVolumeCapabilities(caps []*csi.VolumeCapabili
 }
 
 // validateStorageClassParameters validates StorageClass parameters
-func (s *ControllerServer) validateStorageClassParameters(ctx context.Context, parameters map[string]string) error {
+func (s *ControllerServer) validateStorageClassParameters(ctx context.Context, parameters, secrets map[string]string) error {
 	// Validate compression algorithm
 	if val, ok := parameters[paramCompression]; ok {
 		if _, valid := ValidCompressionAlgorithms[strings.ToUpper(val)]; !valid {
@@ -212,7 +212,7 @@ func (s *ControllerServer) validateStorageClassParameters(ctx context.Context, p
 	}
 
 	// Validate NVMe-oF DH-CHAP parameters
-	if err := validateNVMeOFParameters(parameters); err != nil {
+	if err := validateNVMeOFParameters(parameters, secrets); err != nil {
 		return err
 	}
 
@@ -310,8 +310,16 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 		parameters = make(map[string]string)
 	}
 
+	// Sensitive values (iSCSI CHAP secrets, ZFS encryption keys) may be supplied
+	// via a Kubernetes Secret referenced by the csi.storage.k8s.io/provisioner-secret-*
+	// StorageClass parameters; the external-provisioner resolves the Secret and
+	// passes its data here. Values from secrets take precedence over the matching
+	// StorageClass parameter and are never written to the PersistentVolume volume
+	// context, keeping them out of the StorageClass and etcd.
+	secrets := req.GetSecrets()
+
 	// Validate StorageClass parameters
-	if err := s.validateStorageClassParameters(ctx, parameters); err != nil {
+	if err := s.validateStorageClassParameters(ctx, parameters, secrets); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid storage class parameters: %v", err)
 	}
 
@@ -379,7 +387,7 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 
 		// Same idempotent-repair for NVMe-oF ZVOLs.
 		if existingDataset.Type == datasetTypeVolume && protocol == ProtocolNVMeOF {
-			volCtx, err := s.ensureNVMeOFChain(ctx, volumeID, datasetPath, parameters)
+			volCtx, err := s.ensureNVMeOFChain(ctx, volumeID, datasetPath, parameters, secrets)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to ensure NVMe-oF resources for existing volume: %v", err)
 			}
@@ -411,17 +419,17 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 	}
 
 	if req.VolumeContentSource != nil {
-		return s.createVolumeFromSource(ctx, req, volumeID, datasetPath, protocol, parameters)
+		return s.createVolumeFromSource(ctx, req, volumeID, datasetPath, protocol, parameters, secrets)
 	}
 
 	var volInfo *VolumeInfo
 	switch protocol {
 	case ProtocolISCSI:
-		volInfo, err = s.createISCSIVolume(ctx, volumeID, datasetPath, requiredBytes, parameters)
+		volInfo, err = s.createISCSIVolume(ctx, volumeID, datasetPath, requiredBytes, parameters, secrets)
 	case ProtocolNVMeOF:
-		volInfo, err = s.createNVMeOFVolume(ctx, volumeID, datasetPath, requiredBytes, parameters)
+		volInfo, err = s.createNVMeOFVolume(ctx, volumeID, datasetPath, requiredBytes, parameters, secrets)
 	default:
-		volInfo, err = s.createNFSVolume(ctx, volumeID, datasetPath, requiredBytes, parameters)
+		volInfo, err = s.createNFSVolume(ctx, volumeID, datasetPath, requiredBytes, parameters, secrets)
 	}
 
 	if err != nil {
@@ -442,7 +450,7 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 }
 
 // createNFSVolume creates a ZFS filesystem dataset and NFS share for the volume.
-func (s *ControllerServer) createNFSVolume(ctx context.Context, volumeID, datasetPath string, capacityBytes int64, parameters map[string]string) (*VolumeInfo, error) {
+func (s *ControllerServer) createNFSVolume(ctx context.Context, volumeID, datasetPath string, capacityBytes int64, parameters, secrets map[string]string) (*VolumeInfo, error) {
 	compression := CompressionLZ4
 	if val, ok := parameters[paramCompression]; ok {
 		compression = strings.ToUpper(val)
@@ -474,7 +482,7 @@ func (s *ControllerServer) createNFSVolume(ctx context.Context, volumeID, datase
 	}
 
 	// Add encryption options if configured
-	if encOpts := parseEncryptionOptions(parameters); encOpts != nil {
+	if encOpts := parseEncryptionOptions(parameters, secrets); encOpts != nil {
 		datasetOpts.Encryption = true
 		datasetOpts.EncryptionOptions = encOpts
 		inheritEncryption := false
@@ -599,10 +607,10 @@ var validNVMeOFDHGroups = map[string]bool{
 }
 
 // validateNVMeOFParameters validates the NVMe-oF DH-CHAP StorageClass parameters.
-func validateNVMeOFParameters(parameters map[string]string) error {
+func validateNVMeOFParameters(parameters, secrets map[string]string) error {
 	hostNQN := parameters[paramNVMeOFHostNQN]
-	key := parameters[paramNVMeOFDHCHAPKey]
-	ctrlKey := parameters[paramNVMeOFDHCHAPCtrlKey]
+	key := secretOrParam(secrets, parameters, paramNVMeOFDHCHAPKey)
+	ctrlKey := secretOrParam(secrets, parameters, paramNVMeOFDHCHAPCtrlKey)
 
 	if key != "" && hostNQN == "" {
 		return fmt.Errorf("%s is required when %s is set", paramNVMeOFHostNQN, paramNVMeOFDHCHAPKey)
@@ -643,7 +651,7 @@ func makeNVMeSubsysName(volumeID string) string {
 // buildZVOLCreateOptions builds the dataset create options for a ZVOL, shared by
 // the iSCSI and NVMe-oF volume creation paths (compression, volblocksize, sparse,
 // zfs.* properties, encryption, ancestor creation).
-func (s *ControllerServer) buildZVOLCreateOptions(datasetPath string, capacityBytes int64, parameters map[string]string) *client.DatasetCreateOptions {
+func (s *ControllerServer) buildZVOLCreateOptions(datasetPath string, capacityBytes int64, parameters, secrets map[string]string) *client.DatasetCreateOptions {
 	compression := CompressionLZ4
 	if val, ok := parameters[paramCompression]; ok {
 		compression = strings.ToUpper(val)
@@ -679,7 +687,7 @@ func (s *ControllerServer) buildZVOLCreateOptions(datasetPath string, capacityBy
 		}
 	}
 
-	if encOpts := parseEncryptionOptions(parameters); encOpts != nil {
+	if encOpts := parseEncryptionOptions(parameters, secrets); encOpts != nil {
 		opts.Encryption = true
 		opts.EncryptionOptions = encOpts
 		inheritEncryption := false
@@ -693,7 +701,7 @@ func (s *ControllerServer) buildZVOLCreateOptions(datasetPath string, capacityBy
 // ensureNVMeHost gets or creates a shared nvmet host for the StorageClass's hostNQN.
 // Hosts are shared across all volumes in a StorageClass; concurrent creation is
 // tolerated by re-querying on conflict.
-func (s *ControllerServer) ensureNVMeHost(ctx context.Context, parameters map[string]string) (int, error) {
+func (s *ControllerServer) ensureNVMeHost(ctx context.Context, parameters, secrets map[string]string) (int, error) {
 	hostNQN := parameters[paramNVMeOFHostNQN]
 	if hostNQN == "" {
 		return 0, fmt.Errorf("nvmeof.hostNQN is required for DH-CHAP")
@@ -707,8 +715,8 @@ func (s *ControllerServer) ensureNVMeHost(ctx context.Context, parameters map[st
 
 	opts := &client.NVMeHostCreateOptions{
 		HostNQN:       hostNQN,
-		DHCHAPKey:     parameters[paramNVMeOFDHCHAPKey],
-		DHCHAPCtrlKey: parameters[paramNVMeOFDHCHAPCtrlKey],
+		DHCHAPKey:     secretOrParam(secrets, parameters, paramNVMeOFDHCHAPKey),
+		DHCHAPCtrlKey: secretOrParam(secrets, parameters, paramNVMeOFDHCHAPCtrlKey),
 		DHCHAPHash:    parameters[paramNVMeOFDHCHAPHash],
 		DHCHAPDHGroup: parameters[paramNVMeOFDHCHAPDHGroup],
 	}
@@ -726,13 +734,13 @@ func (s *ControllerServer) ensureNVMeHost(ctx context.Context, parameters map[st
 // createNVMeOFVolume creates a ZVOL and the NVMe-oF subsystem/namespace/port chain
 // (plus DH-CHAP host authorization when configured). Cleanup on failure is reverse
 // order; the shared port and shared host are never deleted here.
-func (s *ControllerServer) createNVMeOFVolume(ctx context.Context, volumeID, datasetPath string, capacityBytes int64, parameters map[string]string) (*VolumeInfo, error) {
+func (s *ControllerServer) createNVMeOFVolume(ctx context.Context, volumeID, datasetPath string, capacityBytes int64, parameters, secrets map[string]string) (*VolumeInfo, error) {
 	portID, err := s.driver.NVMeOFPortID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve NVMe-oF port: %w", err)
 	}
 
-	datasetOpts := s.buildZVOLCreateOptions(datasetPath, capacityBytes, parameters)
+	datasetOpts := s.buildZVOLCreateOptions(datasetPath, capacityBytes, parameters, secrets)
 	if _, err := s.driver.Client().CreateDataset(ctx, datasetOpts); err != nil {
 		return nil, fmt.Errorf("failed to create ZVOL: %w", err)
 	}
@@ -767,7 +775,7 @@ func (s *ControllerServer) createNVMeOFVolume(ctx context.Context, volumeID, dat
 
 	var hostID, hostSubsysID int
 	if hostNQN != "" {
-		hostID, err = s.ensureNVMeHost(ctx, parameters)
+		hostID, err = s.ensureNVMeHost(ctx, parameters, secrets)
 		if err != nil {
 			s.driver.Client().DeleteNVMePortSubsys(ctx, portSubsys.ID)
 			s.driver.Client().DeleteNVMeNamespace(ctx, ns.ID)
@@ -815,7 +823,7 @@ func (s *ControllerServer) createNVMeOFVolume(ctx context.Context, volumeID, dat
 // ensureNVMeOFChain verifies the NVMe-oF subsystem/namespace/port chain exists for
 // an existing ZVOL and creates any missing pieces (mirrors ensureISCSIChain for a
 // CreateVolume interrupted after the ZVOL was created). Returns the volume context.
-func (s *ControllerServer) ensureNVMeOFChain(ctx context.Context, volumeID, datasetPath string, parameters map[string]string) (map[string]string, error) {
+func (s *ControllerServer) ensureNVMeOFChain(ctx context.Context, volumeID, datasetPath string, parameters, secrets map[string]string) (map[string]string, error) {
 	zvolPath := "zvol/" + datasetPath
 
 	// If the namespace already exists, the chain is complete.
@@ -856,7 +864,7 @@ func (s *ControllerServer) ensureNVMeOFChain(ctx context.Context, volumeID, data
 	}
 
 	if hostNQN != "" {
-		hostID, err := s.ensureNVMeHost(ctx, parameters)
+		hostID, err := s.ensureNVMeHost(ctx, parameters, secrets)
 		if err != nil {
 			return nil, err
 		}
@@ -1045,14 +1053,26 @@ func copyParameters(m map[string]string) map[string]string {
 	return out
 }
 
+// secretOrParam returns the value for key from CSI secrets if present and
+// non-empty, otherwise the StorageClass parameter of the same key. It lets
+// sensitive fields (CHAP secrets, encryption keys/passphrases) be sourced from
+// a Kubernetes Secret while preserving backward compatibility with inline
+// StorageClass parameters.
+func secretOrParam(secrets, parameters map[string]string, key string) string {
+	if v, ok := secrets[key]; ok && v != "" {
+		return v
+	}
+	return parameters[key]
+}
+
 // createISCSIVolume creates a ZVOL with iSCSI target, extent, and optional CHAP authentication.
-func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, datasetPath string, capacityBytes int64, parameters map[string]string) (*VolumeInfo, error) {
+func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, datasetPath string, capacityBytes int64, parameters, secrets map[string]string) (*VolumeInfo, error) {
 	portalID, err := s.driver.ISCSIPortalID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve iSCSI portal ID: %w", err)
 	}
 
-	datasetOpts := s.buildZVOLCreateOptions(datasetPath, capacityBytes, parameters)
+	datasetOpts := s.buildZVOLCreateOptions(datasetPath, capacityBytes, parameters, secrets)
 
 	_, err = s.driver.Client().CreateDataset(ctx, datasetOpts)
 	if err != nil {
@@ -1063,7 +1083,7 @@ func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, data
 	var authID int
 	var authTag int
 	if chapUser, ok := parameters[paramISCSIChapUser]; ok && chapUser != "" {
-		chapSecret := parameters[paramISCSIChapSecret]
+		chapSecret := secretOrParam(secrets, parameters, paramISCSIChapSecret)
 		if chapSecret == "" {
 			s.driver.Client().DeleteDataset(ctx, datasetPath, &client.DatasetDeleteOptions{Recursive: true, Force: true})
 			return nil, fmt.Errorf("iscsi.chapSecret is required when iscsi.chapUser is specified")
@@ -1085,7 +1105,7 @@ func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, data
 		// Add mutual CHAP if provided
 		if peerUser, ok := parameters[paramISCSIChapPeerUser]; ok && peerUser != "" {
 			authOpts.PeerUser = peerUser
-			authOpts.PeerSecret = parameters[paramISCSIChapPeerSecret]
+			authOpts.PeerSecret = secretOrParam(secrets, parameters, paramISCSIChapPeerSecret)
 			authOpts.DiscoveryAuth = iscsiAuthTypeMutual
 		}
 
@@ -1208,7 +1228,7 @@ func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, data
 }
 
 // createVolumeFromSource creates a volume from a snapshot or existing volume by cloning.
-func (s *ControllerServer) createVolumeFromSource(ctx context.Context, req *csi.CreateVolumeRequest, volumeID, datasetPath, protocol string, parameters map[string]string) (*csi.CreateVolumeResponse, error) {
+func (s *ControllerServer) createVolumeFromSource(ctx context.Context, req *csi.CreateVolumeRequest, volumeID, datasetPath, protocol string, parameters, secrets map[string]string) (*csi.CreateVolumeResponse, error) {
 	s.driver.Log().V(LogLevelDebug).Info("Creating volume from content source", "volumeId", volumeID)
 	contentSource := req.VolumeContentSource
 
@@ -1227,7 +1247,7 @@ func (s *ControllerServer) createVolumeFromSource(ctx context.Context, req *csi.
 		if existingDataset.Type == datasetTypeVolume && isZVOLProtocol(protocol) {
 			var volCtx map[string]string
 			if protocol == ProtocolNVMeOF {
-				volCtx, err = s.ensureNVMeOFChain(ctx, volumeID, datasetPath, parameters)
+				volCtx, err = s.ensureNVMeOFChain(ctx, volumeID, datasetPath, parameters, secrets)
 			} else {
 				volCtx, err = s.ensureISCSIChain(ctx, volumeID, datasetPath, parameters)
 			}
@@ -1304,7 +1324,7 @@ func (s *ControllerServer) createVolumeFromSource(ctx context.Context, req *csi.
 		case ProtocolISCSI:
 			volInfo, err = s.createISCSITargetForClone(ctx, volumeID, datasetPath, requiredBytes, parameters)
 		case ProtocolNVMeOF:
-			volInfo, err = s.createNVMeOFTargetForClone(ctx, volumeID, datasetPath, requiredBytes, parameters)
+			volInfo, err = s.createNVMeOFTargetForClone(ctx, volumeID, datasetPath, requiredBytes, parameters, secrets)
 		default:
 			volInfo, err = s.createNFSShareForClone(ctx, volumeID, datasetPath, dataset, parameters)
 		}
@@ -1390,7 +1410,7 @@ func (s *ControllerServer) createVolumeFromSource(ctx context.Context, req *csi.
 		case ProtocolISCSI:
 			volInfo, err = s.createISCSITargetForClone(ctx, volumeID, datasetPath, requiredBytes, parameters)
 		case ProtocolNVMeOF:
-			volInfo, err = s.createNVMeOFTargetForClone(ctx, volumeID, datasetPath, requiredBytes, parameters)
+			volInfo, err = s.createNVMeOFTargetForClone(ctx, volumeID, datasetPath, requiredBytes, parameters, secrets)
 		default:
 			volInfo, err = s.createNFSShareForClone(ctx, volumeID, datasetPath, dataset, parameters)
 		}
@@ -1543,7 +1563,7 @@ func isZVOLProtocol(protocol string) bool {
 // createNVMeOFTargetForClone builds the NVMe-oF chain for an already-cloned ZVOL
 // (subsystem + namespace + port link, plus DH-CHAP host authorization when set).
 // Mirrors createISCSITargetForClone; the dataset already exists (it was cloned).
-func (s *ControllerServer) createNVMeOFTargetForClone(ctx context.Context, volumeID, datasetPath string, capacityBytes int64, parameters map[string]string) (*VolumeInfo, error) {
+func (s *ControllerServer) createNVMeOFTargetForClone(ctx context.Context, volumeID, datasetPath string, capacityBytes int64, parameters, secrets map[string]string) (*VolumeInfo, error) {
 	portID, err := s.driver.NVMeOFPortID(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve NVMe-oF port: %w", err)
@@ -1573,7 +1593,7 @@ func (s *ControllerServer) createNVMeOFTargetForClone(ctx context.Context, volum
 
 	var hostID, hostSubsysID int
 	if hostNQN != "" {
-		hostID, err = s.ensureNVMeHost(ctx, parameters)
+		hostID, err = s.ensureNVMeHost(ctx, parameters, secrets)
 		if err != nil {
 			s.driver.Client().DeleteNVMePortSubsys(ctx, portSubsys.ID)
 			s.driver.Client().DeleteNVMeNamespace(ctx, ns.ID)
@@ -2361,7 +2381,7 @@ func (s *ControllerServer) ControllerGetVolume(ctx context.Context, req *csi.Con
 //   - encryption.pbkdf2iters: PBKDF2 iterations (default 350000, min 100000)
 //
 // Returns nil if encryption is not enabled.
-func parseEncryptionOptions(parameters map[string]string) *client.EncryptionOptions {
+func parseEncryptionOptions(parameters, secrets map[string]string) *client.EncryptionOptions {
 	enabled, ok := parameters[paramEncryption]
 	if !ok || !strings.EqualFold(enabled, "true") {
 		return nil
@@ -2376,13 +2396,13 @@ func parseEncryptionOptions(parameters map[string]string) *client.EncryptionOpti
 		opts.Algorithm = strings.ToUpper(val)
 	}
 
-	// Passphrase
-	if val, ok := parameters[paramEncryptionPassphrase]; ok && val != "" {
+	// Passphrase (from Secret or StorageClass parameter)
+	if val := secretOrParam(secrets, parameters, paramEncryptionPassphrase); val != "" {
 		opts.Passphrase = &val
 	}
 
-	// Key (hex-encoded, 64 chars)
-	if val, ok := parameters[paramEncryptionKey]; ok && val != "" {
+	// Key (hex-encoded, 64 chars; from Secret or StorageClass parameter)
+	if val := secretOrParam(secrets, parameters, paramEncryptionKey); val != "" {
 		opts.Key = &val
 	}
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -135,7 +135,11 @@ type StageRequest struct {
 	VolumeCapability *csi.VolumeCapability
 	PublishContext   map[string]string
 	VolumeContext    map[string]string
-	IsBlockVolume    bool // true for raw block volumes (no filesystem)
+	// Secrets carries the CSI node-stage secret (from the StorageClass
+	// csi.storage.k8s.io/node-stage-secret-* parameters). Used to source iSCSI
+	// CHAP login credentials without persisting them in the volume context.
+	Secrets       map[string]string
+	IsBlockVolume bool // true for raw block volumes (no filesystem)
 }
 
 // UnstageRequest contains all information needed to unstage a volume

--- a/pkg/driver/iscsi.go
+++ b/pkg/driver/iscsi.go
@@ -84,8 +84,12 @@ func connectorPath(volumeID string) string {
 	return filepath.Join(connectorDir, fmt.Sprintf("%s.connector", sanitizeISCSIVolumeID(volumeID)))
 }
 
-// parseISCSIConfig extracts iSCSI configuration from publish and volume contexts
-func parseISCSIConfig(publishContext, volumeContext map[string]string) (*ISCSIConfig, error) {
+// parseISCSIConfig extracts iSCSI configuration from publish and volume contexts.
+// CHAP credentials are sourced from the CSI node-stage secret when present,
+// falling back to the volume context (StorageClass parameters) for backward
+// compatibility. Using a secret keeps the credentials out of the persisted
+// PersistentVolume volume context.
+func parseISCSIConfig(publishContext, volumeContext, secrets map[string]string) (*ISCSIConfig, error) {
 	config := &ISCSIConfig{
 		TargetPortal: publishContext[PublishContextTargetPortal],
 		TargetIQN:    publishContext[PublishContextTargetIQN],
@@ -100,11 +104,12 @@ func parseISCSIConfig(publishContext, volumeContext map[string]string) (*ISCSICo
 		config.LUN = int32(lun)
 	}
 
-	// CHAP credentials from volume context (StorageClass parameters)
-	config.CHAPUsername = volumeContext[paramCHAPUsername]
-	config.CHAPPassword = volumeContext[paramCHAPPassword]
-	config.CHAPUsernameIn = volumeContext[paramCHAPUsernameIn]
-	config.CHAPPasswordIn = volumeContext[paramCHAPPasswordIn]
+	// CHAP credentials from the node-stage secret or, as a fallback, the volume
+	// context (StorageClass parameters).
+	config.CHAPUsername = secretOrParam(secrets, volumeContext, paramCHAPUsername)
+	config.CHAPPassword = secretOrParam(secrets, volumeContext, paramCHAPPassword)
+	config.CHAPUsernameIn = secretOrParam(secrets, volumeContext, paramCHAPUsernameIn)
+	config.CHAPPasswordIn = secretOrParam(secrets, volumeContext, paramCHAPPasswordIn)
 
 	// Multipath and persistent sessions
 	if val := volumeContext[paramMultipathEnabled]; strings.EqualFold(val, "true") {
@@ -149,7 +154,7 @@ func (h *ISCSIHandler) Stage(ctx context.Context, req *StageRequest) (*StageResu
 	h.log.V(LogLevelDebug).Info("iSCSI Stage", "volumeId", req.VolumeID, "stagingPath", req.StagingPath, "isBlock", req.IsBlockVolume)
 
 	// Parse iSCSI configuration
-	config, err := parseISCSIConfig(req.PublishContext, req.VolumeContext)
+	config, err := parseISCSIConfig(req.PublishContext, req.VolumeContext, req.Secrets)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse iSCSI config: %w (check publish context from controller)", err)
 	}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -201,6 +201,7 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		VolumeCapability: req.VolumeCapability,
 		PublishContext:   req.PublishContext,
 		VolumeContext:    req.VolumeContext,
+		Secrets:          req.GetSecrets(),
 		IsBlockVolume:    isBlockVolume,
 	}
 

--- a/pkg/driver/nvmeof.go
+++ b/pkg/driver/nvmeof.go
@@ -87,9 +87,10 @@ func nvmeConnectorPath(volumeID string) string {
 }
 
 // parseNVMeOFConfig extracts NVMe-oF configuration. Connection parameters come from
-// the publish context; DH-CHAP credentials (plaintext StorageClass params) come from
-// the volume context, mirroring how iSCSI CHAP is delivered.
-func parseNVMeOFConfig(publishContext, volumeContext map[string]string) *NVMeOFConfig {
+// the publish context; DH-CHAP credentials come from the node-stage secret when
+// present, falling back to the volume context (StorageClass params) for backward
+// compatibility, mirroring how iSCSI CHAP is delivered.
+func parseNVMeOFConfig(publishContext, volumeContext, secrets map[string]string) *NVMeOFConfig {
 	transport := publishContext[PublishContextNVMeTransport]
 	if transport == "" {
 		transport = defaultNVMeOFTransport
@@ -101,8 +102,8 @@ func parseNVMeOFConfig(publishContext, volumeContext map[string]string) *NVMeOFC
 		Transport:     transport,
 		NamespaceUUID: publishContext[PublishContextNVMeNSUUID],
 		HostNQN:       volumeContext[paramNVMeOFHostNQN],
-		DHCHAPKey:     volumeContext[paramNVMeOFDHCHAPKey],
-		DHCHAPCtrlKey: volumeContext[paramNVMeOFDHCHAPCtrlKey],
+		DHCHAPKey:     secretOrParam(secrets, volumeContext, paramNVMeOFDHCHAPKey),
+		DHCHAPCtrlKey: secretOrParam(secrets, volumeContext, paramNVMeOFDHCHAPCtrlKey),
 	}
 }
 
@@ -111,7 +112,7 @@ func parseNVMeOFConfig(publishContext, volumeContext map[string]string) *NVMeOFC
 func (h *NVMeOFHandler) Stage(ctx context.Context, req *StageRequest) (*StageResult, error) {
 	h.log.V(LogLevelDebug).Info("NVMe-oF Stage", "volumeId", req.VolumeID, "stagingPath", req.StagingPath, "isBlock", req.IsBlockVolume)
 
-	config := parseNVMeOFConfig(req.PublishContext, req.VolumeContext)
+	config := parseNVMeOFConfig(req.PublishContext, req.VolumeContext, req.Secrets)
 	if config.SubNQN == "" || config.PortAddr == "" || config.PortSvcID == "" {
 		return nil, fmt.Errorf("NVMe-oF subsystem NQN and portal are required (check controller publish context)")
 	}

--- a/pkg/driver/nvmeof_test.go
+++ b/pkg/driver/nvmeof_test.go
@@ -60,7 +60,8 @@ func TestParseNVMeOFConfig(t *testing.T) {
 		paramNVMeOFDHCHAPCtrlKey: "DHHC-1:01:ctrl:",
 	}
 
-	cfg := parseNVMeOFConfig(publish, volume)
+	// nil secrets: exercises the volume-context (backward-compatible) path
+	cfg := parseNVMeOFConfig(publish, volume, nil)
 	if cfg.SubNQN != "nqn.2011-06.com.truenas:csi-pvc-abc" {
 		t.Errorf("SubNQN = %q", cfg.SubNQN)
 	}

--- a/pkg/driver/secrets_test.go
+++ b/pkg/driver/secrets_test.go
@@ -1,0 +1,239 @@
+package driver
+
+import "testing"
+
+func TestSecretOrParam(t *testing.T) {
+	tests := []struct {
+		name       string
+		secrets    map[string]string
+		parameters map[string]string
+		key        string
+		want       string
+	}{
+		{
+			name:       "secret takes precedence over parameter",
+			secrets:    map[string]string{"k": "fromSecret"},
+			parameters: map[string]string{"k": "fromParam"},
+			key:        "k",
+			want:       "fromSecret",
+		},
+		{
+			name:       "falls back to parameter when secret absent",
+			secrets:    map[string]string{},
+			parameters: map[string]string{"k": "fromParam"},
+			key:        "k",
+			want:       "fromParam",
+		},
+		{
+			name:       "empty secret value falls back to parameter",
+			secrets:    map[string]string{"k": ""},
+			parameters: map[string]string{"k": "fromParam"},
+			key:        "k",
+			want:       "fromParam",
+		},
+		{
+			name:       "nil secrets falls back to parameter",
+			secrets:    nil,
+			parameters: map[string]string{"k": "fromParam"},
+			key:        "k",
+			want:       "fromParam",
+		},
+		{
+			name:       "missing in both returns empty",
+			secrets:    map[string]string{},
+			parameters: map[string]string{},
+			key:        "k",
+			want:       "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := secretOrParam(tt.secrets, tt.parameters, tt.key); got != tt.want {
+				t.Errorf("secretOrParam() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseEncryptionOptions_KeyFromSecret(t *testing.T) {
+	const key = "0000000000000000000000000000000000000000000000000000000000000000"
+	parameters := map[string]string{paramEncryption: "true"}
+	secrets := map[string]string{paramEncryptionKey: key}
+
+	opts := parseEncryptionOptions(parameters, secrets)
+	if opts == nil {
+		t.Fatal("expected encryption options, got nil")
+	}
+	if opts.Key == nil || *opts.Key != key {
+		t.Errorf("Key = %v, want %q", opts.Key, key)
+	}
+	if opts.GenerateKey {
+		t.Error("GenerateKey should be false when a key is supplied via secret")
+	}
+}
+
+func TestParseEncryptionOptions_SecretOverridesParameter(t *testing.T) {
+	parameters := map[string]string{
+		paramEncryption:    "true",
+		paramEncryptionKey: "inlineKeyFromStorageClass",
+	}
+	secrets := map[string]string{paramEncryptionKey: "keyFromSecret"}
+
+	opts := parseEncryptionOptions(parameters, secrets)
+	if opts == nil || opts.Key == nil {
+		t.Fatal("expected encryption options with key")
+	}
+	if *opts.Key != "keyFromSecret" {
+		t.Errorf("Key = %q, want secret value", *opts.Key)
+	}
+}
+
+func TestParseEncryptionOptions_PassphraseFallsBackToParameter(t *testing.T) {
+	parameters := map[string]string{
+		paramEncryption:           "true",
+		paramEncryptionPassphrase: "inlinePassphrase",
+	}
+	opts := parseEncryptionOptions(parameters, nil)
+	if opts == nil || opts.Passphrase == nil {
+		t.Fatal("expected encryption options with passphrase")
+	}
+	if *opts.Passphrase != "inlinePassphrase" {
+		t.Errorf("Passphrase = %q, want inline parameter value", *opts.Passphrase)
+	}
+}
+
+func TestParseEncryptionOptions_DefaultsToGenerateKey(t *testing.T) {
+	opts := parseEncryptionOptions(map[string]string{paramEncryption: "true"}, nil)
+	if opts == nil {
+		t.Fatal("expected encryption options, got nil")
+	}
+	if !opts.GenerateKey {
+		t.Error("expected GenerateKey=true when no key/passphrase supplied")
+	}
+}
+
+func TestParseEncryptionOptions_DisabledReturnsNil(t *testing.T) {
+	if opts := parseEncryptionOptions(map[string]string{}, map[string]string{paramEncryptionKey: "x"}); opts != nil {
+		t.Errorf("expected nil when encryption not enabled, got %+v", opts)
+	}
+}
+
+func TestParseISCSIConfig_CHAPFromSecret(t *testing.T) {
+	publishContext := map[string]string{
+		PublishContextTargetPortal: "10.0.0.1:3260",
+		PublishContextTargetIQN:    "iqn.2000-01.io.truenas:test",
+	}
+	secrets := map[string]string{
+		paramCHAPUsername:   "userFromSecret",
+		paramCHAPPassword:   "passFromSecret",
+		paramCHAPUsernameIn: "peerUserFromSecret",
+		paramCHAPPasswordIn: "peerPassFromSecret",
+	}
+
+	config, err := parseISCSIConfig(publishContext, nil, secrets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.CHAPUsername != "userFromSecret" || config.CHAPPassword != "passFromSecret" {
+		t.Errorf("CHAP creds not sourced from secret: %+v", config)
+	}
+	if config.CHAPUsernameIn != "peerUserFromSecret" || config.CHAPPasswordIn != "peerPassFromSecret" {
+		t.Errorf("mutual CHAP creds not sourced from secret: %+v", config)
+	}
+}
+
+func TestParseISCSIConfig_CHAPSecretOverridesVolumeContext(t *testing.T) {
+	publishContext := map[string]string{
+		PublishContextTargetPortal: "10.0.0.1:3260",
+		PublishContextTargetIQN:    "iqn.2000-01.io.truenas:test",
+	}
+	volumeContext := map[string]string{
+		paramCHAPUsername: "userFromVolCtx",
+		paramCHAPPassword: "passFromVolCtx",
+	}
+	secrets := map[string]string{
+		paramCHAPUsername: "userFromSecret",
+		paramCHAPPassword: "passFromSecret",
+	}
+
+	config, err := parseISCSIConfig(publishContext, volumeContext, secrets)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.CHAPUsername != "userFromSecret" || config.CHAPPassword != "passFromSecret" {
+		t.Errorf("secret should override volume context: %+v", config)
+	}
+}
+
+func TestParseISCSIConfig_CHAPFallsBackToVolumeContext(t *testing.T) {
+	publishContext := map[string]string{
+		PublishContextTargetPortal: "10.0.0.1:3260",
+		PublishContextTargetIQN:    "iqn.2000-01.io.truenas:test",
+	}
+	volumeContext := map[string]string{
+		paramCHAPUsername: "userFromVolCtx",
+		paramCHAPPassword: "passFromVolCtx",
+	}
+
+	config, err := parseISCSIConfig(publishContext, volumeContext, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if config.CHAPUsername != "userFromVolCtx" || config.CHAPPassword != "passFromVolCtx" {
+		t.Errorf("expected fallback to volume context: %+v", config)
+	}
+}
+
+func TestParseNVMeOFConfig_DHCHAPFromSecret(t *testing.T) {
+	publishContext := map[string]string{
+		PublishContextNVMeSubNQN:    "nqn.2011-06.com.truenas:csi",
+		PublishContextNVMePortAddr:  "10.0.0.1",
+		PublishContextNVMePortSvcID: "4420",
+	}
+	secrets := map[string]string{
+		paramNVMeOFDHCHAPKey:     "DHHC-1:00:keyFromSecret:",
+		paramNVMeOFDHCHAPCtrlKey: "DHHC-1:00:ctrlFromSecret:",
+	}
+
+	cfg := parseNVMeOFConfig(publishContext, nil, secrets)
+	if cfg.DHCHAPKey != "DHHC-1:00:keyFromSecret:" || cfg.DHCHAPCtrlKey != "DHHC-1:00:ctrlFromSecret:" {
+		t.Errorf("DH-CHAP keys not sourced from secret: %q / %q", cfg.DHCHAPKey, cfg.DHCHAPCtrlKey)
+	}
+}
+
+func TestParseNVMeOFConfig_DHCHAPSecretOverridesVolumeContext(t *testing.T) {
+	publishContext := map[string]string{
+		PublishContextNVMeSubNQN:    "nqn.2011-06.com.truenas:csi",
+		PublishContextNVMePortAddr:  "10.0.0.1",
+		PublishContextNVMePortSvcID: "4420",
+	}
+	volumeContext := map[string]string{paramNVMeOFDHCHAPKey: "DHHC-1:00:keyFromVolCtx:"}
+	secrets := map[string]string{paramNVMeOFDHCHAPKey: "DHHC-1:00:keyFromSecret:"}
+
+	cfg := parseNVMeOFConfig(publishContext, volumeContext, secrets)
+	if cfg.DHCHAPKey != "DHHC-1:00:keyFromSecret:" {
+		t.Errorf("secret should override volume context: %q", cfg.DHCHAPKey)
+	}
+}
+
+func TestValidateNVMeOFParameters_KeyFromSecretSatisfiesValidation(t *testing.T) {
+	// hostNQN inline, DH-CHAP key supplied via secret: validation must see the
+	// effective key (from the secret) and not error.
+	parameters := map[string]string{paramNVMeOFHostNQN: "nqn.2014-08.org.nvmexpress:uuid:node-a"}
+	secrets := map[string]string{paramNVMeOFDHCHAPKey: "DHHC-1:00:key:"}
+
+	if err := validateNVMeOFParameters(parameters, secrets); err != nil {
+		t.Errorf("unexpected validation error: %v", err)
+	}
+}
+
+func TestValidateNVMeOFParameters_KeyFromSecretRequiresHostNQN(t *testing.T) {
+	// DH-CHAP key via secret but no hostNQN: validation must catch it using the
+	// effective (secret-sourced) key.
+	secrets := map[string]string{paramNVMeOFDHCHAPKey: "DHHC-1:00:key:"}
+
+	if err := validateNVMeOFParameters(map[string]string{}, secrets); err == nil {
+		t.Error("expected error when DH-CHAP key set (via secret) without hostNQN")
+	}
+}


### PR DESCRIPTION
Sensitive StorageClass values can now be supplied via a Kubernetes Secret referenced by the CSI secret parameters, instead of plaintext in the StorageClass. Values from a Secret take precedence over the matching inline parameter and are never written to the PersistentVolume volume context, so they stay out of the StorageClass and etcd. Inline parameters keep working unchanged (backward compatible).

Sensitive fields covered:
- iSCSI CHAP: iscsi.chapSecret / iscsi.chapPeerSecret (controller, provisioner-secret) and iscsi.chapUsername / iscsi.chapPassword / iscsi.chapUsernameIn / iscsi.chapPasswordIn (node, node-stage-secret)
- NVMe-oF DH-CHAP: nvmeof.dhchapKey / nvmeof.dhchapCtrlKey (both provisioner- and node-stage-secret)
- ZFS encryption: encryption.key / encryption.passphrase (provisioner-secret)

Implementation:
- add secretOrParam() helper; CreateVolume captures req.GetSecrets() and threads it through the iSCSI/NVMe-oF/NFS create paths, encryption options, and NVMe-oF validation/host-registration (incl. clone paths)
- NodeStageVolume passes req.GetSecrets() through StageRequest; parseISCSIConfig and parseNVMeOFConfig prefer the node-stage secret, falling back to volume context
- grant the controller ServiceAccount get/list on secrets in the deploy manifest so external-provisioner can resolve the provisioner-secret
- unit tests for secret precedence/fallback across all parsers and NVMe-oF validation; example StorageClasses and README documentation

The API key is already Secret-based; NFS access-control params are not credentials and are unchanged.