### PR TITLE
make iSCSI CHAP work end to end (including mutual CHAP)

### DIFF
--- a/pkg/client/storage.go
+++ b/pkg/client/storage.go
@@ -840,20 +840,25 @@ func (c *Client) GetISCSITargetByID(ctx context.Context, id int) (*ISCSITarget, 
 
 // CreateISCSITarget creates a new iSCSI target with the specified name and alias.
 func (c *Client) CreateISCSITarget(ctx context.Context, name, alias string, portalID int) (*ISCSITarget, error) {
-	return c.CreateISCSITargetWithAuth(ctx, name, alias, portalID, 0, 0)
+	return c.CreateISCSITargetWithAuth(ctx, name, alias, portalID, 0, 0, false)
 }
 
 // CreateISCSITargetWithAuth creates a new iSCSI target with optional auth and initiator groups.
 // portalID: TrueNAS portal group ID (required)
 // authTag: CHAP authentication group tag (0 to skip)
 // initiatorID: Initiator group ID (0 to skip)
-func (c *Client) CreateISCSITargetWithAuth(ctx context.Context, name, alias string, portalID, authTag, initiatorID int) (*ISCSITarget, error) {
+// mutualCHAP: when true (and authTag > 0) the target group uses CHAP_MUTUAL, so the
+// target authenticates back to the initiator using the auth group's peer credentials.
+func (c *Client) CreateISCSITargetWithAuth(ctx context.Context, name, alias string, portalID, authTag, initiatorID int, mutualCHAP bool) (*ISCSITarget, error) {
 	group := ISCSITargetGroup{
 		Portal: portalID,
 	}
 
 	if authTag > 0 {
 		group.AuthMethod = "CHAP"
+		if mutualCHAP {
+			group.AuthMethod = "CHAP_MUTUAL"
+		}
 		group.Auth = authTag
 	}
 

--- a/pkg/client/storage_test.go
+++ b/pkg/client/storage_test.go
@@ -408,7 +408,7 @@ func TestCreateISCSITargetWithAuth_Success(t *testing.T) {
 
 	client := connectTestClient(t, mock)
 
-	target, err := client.CreateISCSITargetWithAuth(testContext(t), "target2", "alias2", 1, 5, 10)
+	target, err := client.CreateISCSITargetWithAuth(testContext(t), "target2", "alias2", 1, 5, 10, false)
 
 	assertNoError(t, err)
 	assertNotNil(t, target)
@@ -417,6 +417,38 @@ func TestCreateISCSITargetWithAuth_Success(t *testing.T) {
 	assertEqual(t, target.Groups[0].AuthMethod, "CHAP")
 	assertEqual(t, target.Groups[0].Auth, 5)
 	assertEqual(t, target.Groups[0].Initiator, 10)
+}
+
+func TestCreateISCSITargetWithAuth_MutualCHAP(t *testing.T) {
+	mock := NewMockTrueNASServer()
+	defer mock.Close()
+
+	// Capture the create params to assert the target group requests mutual CHAP.
+	mock.SetResponse(methodISCSITargetCreate, MockResponse{
+		Result: ISCSITarget{
+			ID:    3,
+			Name:  "target3",
+			Alias: "alias3",
+			Mode:  "ISCSI",
+			Groups: []ISCSITargetGroup{
+				{Portal: 1, AuthMethod: "CHAP_MUTUAL", Auth: 7},
+			},
+		},
+	})
+
+	client := connectTestClient(t, mock)
+
+	_, err := client.CreateISCSITargetWithAuth(testContext(t), "target3", "alias3", 1, 7, 0, true)
+	assertNoError(t, err)
+
+	// The request sent to TrueNAS must set authmethod=CHAP_MUTUAL on the group.
+	params := firstParamMap(t, mock, methodISCSITargetCreate)
+	groups, ok := params["groups"].([]any)
+	if !ok || len(groups) == 0 {
+		t.Fatalf("expected groups in create params, got %#v", params["groups"])
+	}
+	group := groups[0].(map[string]any)
+	assertEqual(t, group["authmethod"].(string), "CHAP_MUTUAL")
 }
 
 func TestGetISCSITargetByName_Success(t *testing.T) {

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -82,9 +82,8 @@ const (
 	paramISCSIChapPeerSecret = "iscsi.chapPeerSecret"
 	paramISCSIInitiators     = "iscsi.initiators"
 
-	// iSCSI auth types
-	iscsiAuthTypeCHAP   = "chap"
-	iscsiAuthTypeMutual = "CHAP_MUTUAL"
+	// iSCSI auth type for the node-side connector (csi-lib-iscsi expects "chap")
+	iscsiAuthTypeCHAP = "chap"
 
 	// NVMe-oF parameters. DH-CHAP credentials are plaintext StorageClass params
 	// (like iSCSI CHAP) and flow to the node via the volume context.
@@ -968,7 +967,7 @@ func (s *ControllerServer) ensureISCSIChain(ctx context.Context, volumeID, datas
 		// Extent doesn't exist - create it along with target and association
 		s.driver.Log().Info("iSCSI extent missing for existing ZVOL, completing iSCSI setup", "volumeId", volumeID, "zvolPath", zvolPath)
 
-		target, err := s.driver.Client().CreateISCSITargetWithAuth(ctx, targetSuffix, fmt.Sprintf("CSI volume %s", volumeID), portalID, 0, 0)
+		target, err := s.driver.Client().CreateISCSITargetWithAuth(ctx, targetSuffix, fmt.Sprintf("CSI volume %s", volumeID), portalID, 0, 0, false)
 		if err != nil {
 			// Target may already exist from a partial creation
 			target, err = s.driver.Client().GetISCSITargetByName(ctx, targetSuffix)
@@ -1002,7 +1001,7 @@ func (s *ControllerServer) ensureISCSIChain(ctx context.Context, volumeID, datas
 		// Find or create the target, then create the association.
 		s.driver.Log().Info("iSCSI target-extent association missing, completing setup", "volumeId", volumeID, "extentId", extent.ID)
 
-		target, tErr := s.driver.Client().CreateISCSITargetWithAuth(ctx, targetSuffix, fmt.Sprintf("CSI volume %s", volumeID), portalID, 0, 0)
+		target, tErr := s.driver.Client().CreateISCSITargetWithAuth(ctx, targetSuffix, fmt.Sprintf("CSI volume %s", volumeID), portalID, 0, 0, false)
 		if tErr != nil {
 			target, tErr = s.driver.Client().GetISCSITargetByName(ctx, targetSuffix)
 			if tErr != nil {
@@ -1062,6 +1061,7 @@ func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, data
 	// Create CHAP auth group if credentials are provided
 	var authID int
 	var authTag int
+	var mutualCHAP bool
 	if chapUser, ok := parameters[paramISCSIChapUser]; ok && chapUser != "" {
 		chapSecret := parameters[paramISCSIChapSecret]
 		if chapSecret == "" {
@@ -1086,7 +1086,12 @@ func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, data
 		if peerUser, ok := parameters[paramISCSIChapPeerUser]; ok && peerUser != "" {
 			authOpts.PeerUser = peerUser
 			authOpts.PeerSecret = parameters[paramISCSIChapPeerSecret]
-			authOpts.DiscoveryAuth = iscsiAuthTypeMutual
+			// Mutual CHAP is enforced at the target group (authmethod=CHAP_MUTUAL),
+			// not via discovery_auth on the per-volume auth group: discovery auth is
+			// a portal-level setting, so stamping it per volume collides across
+			// volumes. The auth group still carries peeruser/peersecret, which the
+			// target uses to authenticate back to the initiator.
+			mutualCHAP = true
 		}
 
 		auth, err := s.driver.Client().CreateISCSIAuth(ctx, authOpts)
@@ -1124,7 +1129,7 @@ func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, data
 	iqnBase := s.driver.GetISCSIIQNBaseFromParameters(parameters)
 
 	targetSuffix := makeISCSITargetSuffix(volumeID)
-	target, err := s.driver.Client().CreateISCSITargetWithAuth(ctx, targetSuffix, fmt.Sprintf("CSI volume %s", volumeID), portalID, authTag, initiatorID)
+	target, err := s.driver.Client().CreateISCSITargetWithAuth(ctx, targetSuffix, fmt.Sprintf("CSI volume %s", volumeID), portalID, authTag, initiatorID, mutualCHAP)
 	if err != nil {
 		// Cleanup auth and initiator if created
 		if initiatorID > 0 {

--- a/pkg/driver/iscsi.go
+++ b/pkg/driver/iscsi.go
@@ -129,16 +129,29 @@ func (h *ISCSIHandler) buildConnector(volumeID string, config *ISCSIConfig) *isc
 		DoDiscovery:   true,
 	}
 
-	// Configure CHAP authentication
+	// Configure CHAP authentication.
+	//
+	// The controller already resolves the exact target IQN and portal, so
+	// sendtargets discovery is unnecessary — and TrueNAS permits only one
+	// CHAP_MUTUAL discovery entry system-wide, so discovery auth cannot be scaled
+	// per volume. For CHAP volumes we therefore skip discovery (DoDiscovery=false)
+	// and log in directly to the known target, enforcing CHAP only at the session
+	// scope (node.session.auth). csi-lib-iscsi applies session CHAP via
+	// CreateDBEntry, which it calls only when DoCHAPDiscovery is set, and only
+	// writes credentials when Secrets.SecretsType == "chap"; Connector.AuthType is
+	// not consulted. No DiscoverySecrets are set since we do not discover.
+	// (Non-CHAP volumes keep the default discovery path.)
 	if config.CHAPUsername != "" && config.CHAPPassword != "" {
+		connector.DoDiscovery = false
+		connector.DoCHAPDiscovery = true
 		connector.AuthType = iscsiAuthTypeCHAP
-		connector.DiscoverySecrets = iscsilib.Secrets{
-			UserName:   config.CHAPUsername,
-			Password:   config.CHAPPassword,
-			UserNameIn: config.CHAPUsernameIn,
-			PasswordIn: config.CHAPPasswordIn,
+		connector.SessionSecrets = iscsilib.Secrets{
+			SecretsType: iscsiAuthTypeCHAP,
+			UserName:    config.CHAPUsername,
+			Password:    config.CHAPPassword,
+			UserNameIn:  config.CHAPUsernameIn,
+			PasswordIn:  config.CHAPPasswordIn,
 		}
-		connector.SessionSecrets = connector.DiscoverySecrets
 	}
 
 	return connector

--- a/pkg/driver/iscsi_test.go
+++ b/pkg/driver/iscsi_test.go
@@ -1,0 +1,60 @@
+package driver
+
+import "testing"
+
+// For CHAP volumes, buildConnector must skip sendtargets discovery
+// (DoDiscovery=false) and configure CHAP at the session scope only: the library
+// applies session CHAP via CreateDBEntry, gated on DoCHAPDiscovery, and only when
+// SessionSecrets.SecretsType == "chap". No discovery secrets are set.
+func TestBuildConnector_CHAPEnabled(t *testing.T) {
+	h := &ISCSIHandler{}
+	config := &ISCSIConfig{
+		TargetPortal:   "10.0.0.1:3260",
+		TargetIQN:      "iqn.2000-01.io.truenas:vol",
+		CHAPUsername:   "k8s",
+		CHAPPassword:   "pass1234abcd",
+		CHAPUsernameIn: "truenas",
+		CHAPPasswordIn: "peerpass1234",
+	}
+
+	c := h.buildConnector("vol1", config)
+
+	if c.DoDiscovery {
+		t.Error("DoDiscovery must be false for CHAP volumes (log in directly to the known target)")
+	}
+	if !c.DoCHAPDiscovery {
+		t.Error("DoCHAPDiscovery must be true so CreateDBEntry creates the node record and applies session CHAP")
+	}
+	if c.SessionSecrets.SecretsType != "chap" {
+		t.Errorf("SessionSecrets.SecretsType must be \"chap\", got %q", c.SessionSecrets.SecretsType)
+	}
+	if c.DiscoverySecrets.SecretsType != "" {
+		t.Errorf("DiscoverySecrets must be unset (no discovery), got SecretsType %q", c.DiscoverySecrets.SecretsType)
+	}
+	if c.SessionSecrets.UserName != "k8s" || c.SessionSecrets.Password != "pass1234abcd" {
+		t.Errorf("session credentials not propagated: %+v", c.SessionSecrets)
+	}
+	if c.SessionSecrets.UserNameIn != "truenas" || c.SessionSecrets.PasswordIn != "peerpass1234" {
+		t.Errorf("mutual (incoming) credentials not propagated: %+v", c.SessionSecrets)
+	}
+}
+
+func TestBuildConnector_NoCHAP(t *testing.T) {
+	h := &ISCSIHandler{}
+	c := h.buildConnector("vol1", &ISCSIConfig{
+		TargetPortal: "10.0.0.1:3260",
+		TargetIQN:    "iqn.2000-01.io.truenas:vol",
+	})
+
+	// Non-CHAP volumes are unchanged: discovery on, no CHAP.
+	if !c.DoDiscovery {
+		t.Error("DoDiscovery must remain true for non-CHAP volumes")
+	}
+	if c.DoCHAPDiscovery {
+		t.Error("DoCHAPDiscovery must be false when no CHAP credentials are set")
+	}
+	if c.SessionSecrets.SecretsType != "" || c.DiscoverySecrets.SecretsType != "" {
+		t.Errorf("no secrets should be set without CHAP: session=%q discovery=%q",
+			c.SessionSecrets.SecretsType, c.DiscoverySecrets.SecretsType)
+	}
+}


### PR DESCRIPTION
Three related problems prevented iSCSI CHAP (and mutual CHAP in particular) from working:

1. The controller stamped discovery_auth=CHAP_MUTUAL on the per-volume iscsi.auth group it creates for each volume. discovery_auth is a portal-wide setting and TrueNAS permits only one CHAP_MUTUAL entry system-wide, so the second mutual-CHAP volume was refused. Mutual CHAP now lives on the target group's auth method (CHAP_MUTUAL, referencing the volume's auth tag); the per-volume auth group keeps discovery_auth=NONE but still carries the peer credentials the target uses to authenticate back to the initiator.

2. The node never actually configured CHAP. buildConnector set Connector.AuthType, which csi-lib-iscsi does not consult; the library only writes CHAP when Secrets.SecretsType == "chap", and applies session CHAP (via CreateDBEntry) only when Connector.DoCHAPDiscovery is set.

3. The node performed sendtargets discovery, which needs TrueNAS's global discovery authentication (again limited to one CHAP_MUTUAL entry) and cannot be authenticated per volume. Since the controller already supplies the exact target IQN and portal, CHAP volumes now skip discovery (DoDiscovery=false) and log in directly, enforcing CHAP at the session scope only. Non-CHAP volumes keep the existing discovery path.

Adds unit tests for the target auth method and buildConnector.