### PR TITLE
detect the iSCSI target base name from TrueNAS instead of assuming it

### DIFF
--- a/pkg/client/storage.go
+++ b/pkg/client/storage.go
@@ -42,6 +42,7 @@ const (
 	methodISCSIInitiatorQuery     = "iscsi.initiator.query"
 	methodISCSIInitiatorDelete    = "iscsi.initiator.delete"
 	methodISCSIPortalQuery        = "iscsi.portal.query"
+	methodISCSIGlobalConfig       = "iscsi.global.config"
 )
 
 // TrueNAS API method names for snapshots
@@ -1010,6 +1011,22 @@ func (c *Client) DeleteISCSIAuth(ctx context.Context, id int) error {
 		return fmt.Errorf("failed to delete iSCSI auth %d: %w", id, err)
 	}
 	return nil
+}
+
+// ISCSIGlobalConfig is the iSCSI global configuration (iscsi.global.config).
+type ISCSIGlobalConfig struct {
+	ID       int    `json:"id"`
+	Basename string `json:"basename"`
+}
+
+// GetISCSIGlobalConfig returns the iSCSI global configuration, whose basename is
+// the IQN prefix TrueNAS assigns to every target (e.g. iqn.2005-10.org.freenas.ctl).
+func (c *Client) GetISCSIGlobalConfig(ctx context.Context) (*ISCSIGlobalConfig, error) {
+	var cfg ISCSIGlobalConfig
+	if err := c.Call(ctx, methodISCSIGlobalConfig, []any{}, &cfg); err != nil {
+		return nil, fmt.Errorf("failed to get iSCSI global config: %w", err)
+	}
+	return &cfg, nil
 }
 
 // GetNextISCSIAuthTag returns the next available iSCSI auth tag.

--- a/pkg/client/storage_test.go
+++ b/pkg/client/storage_test.go
@@ -1371,3 +1371,19 @@ func TestZFSProperty_GetString(t *testing.T) {
 		})
 	}
 }
+
+func TestGetISCSIGlobalConfig_Success(t *testing.T) {
+	mock := NewMockTrueNASServer()
+	defer mock.Close()
+
+	mock.SetResponse(methodISCSIGlobalConfig, MockResponse{
+		Result: ISCSIGlobalConfig{ID: 1, Basename: "iqn.2005-10.org.freenas.ctl"},
+	})
+
+	client := connectTestClient(t, mock)
+
+	cfg, err := client.GetISCSIGlobalConfig(testContext(t))
+	assertNoError(t, err)
+	assertNotNil(t, cfg)
+	assertEqual(t, cfg.Basename, "iqn.2005-10.org.freenas.ctl")
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -310,12 +310,14 @@ func NewDriver(config *DriverConfig) (*Driver, error) {
 		return nil, fmt.Errorf("default pool is required")
 	}
 
-	if config.ISCSIIQNBase == "" {
-		config.ISCSIIQNBase = DEFAULT_IQN_BASE
-	}
-
-	if err := validateIQNFormat(config.ISCSIIQNBase); err != nil {
-		return nil, fmt.Errorf("invalid iSCSI IQN base format: %w", err)
+	// If the IQN base is explicitly configured, validate it now. Otherwise it is
+	// auto-detected from TrueNAS's iscsi.global basename after the client connects
+	// (targets are named "<basename>:<target>", and the basename varies by
+	// platform, e.g. iqn.2005-10.org.freenas.ctl), falling back to DEFAULT_IQN_BASE.
+	if config.ISCSIIQNBase != "" {
+		if err := validateIQNFormat(config.ISCSIIQNBase); err != nil {
+			return nil, fmt.Errorf("invalid iSCSI IQN base format: %w", err)
+		}
 	}
 
 	// Derive NFS server from TrueNAS URL if not explicitly set
@@ -419,6 +421,24 @@ func NewDriver(config *DriverConfig) (*Driver, error) {
 	} else {
 		nvmeBaseNQN = gc.BaseNQN
 		log.V(LogLevelInfo).Info("Read nvmet base NQN", "baseNQN", nvmeBaseNQN)
+	}
+
+	// Auto-detect the iSCSI IQN base from TrueNAS when not explicitly configured.
+	// TrueNAS names every target "<iscsi.global basename>:<target>", so the node
+	// must log in to that exact IQN; assuming a fixed base makes the node target a
+	// nonexistent IQN and login fails.
+	if config.ISCSIIQNBase == "" {
+		if gc, err := truenasClient.GetISCSIGlobalConfig(ctx); err == nil && validateIQNFormat(gc.Basename) == nil {
+			config.ISCSIIQNBase = gc.Basename
+			log.V(LogLevelInfo).Info("Detected iSCSI base name from TrueNAS", "basename", gc.Basename)
+		} else {
+			if err != nil {
+				log.V(LogLevelInfo).Info("Failed to read iscsi.global config; using default IQN base", "error", err, "default", DEFAULT_IQN_BASE)
+			} else {
+				log.V(LogLevelInfo).Info("iscsi.global basename invalid; using default IQN base", "basename", gc.Basename, "default", DEFAULT_IQN_BASE)
+			}
+			config.ISCSIIQNBase = DEFAULT_IQN_BASE
+		}
 	}
 
 	// Default to "all" mode if not specified


### PR DESCRIPTION
The driver built every target IQN as "<DEFAULT_IQN_BASE>:<target>", with DEFAULT_IQN_BASE hardcoded to iqn.2000-01.io.truenas. When the assumed base does not match, the published target IQN refers to a target that does not exist, so the node's iSCSI session login fails with a non-retryable login error.

Query iscsi.global.config for the basename at startup (mirroring the existing nvmet.global.config lookup used for NVMe-oF) and use it as the IQN base when one is not explicitly configured, falling back to DEFAULT_IQN_BASE if the query fails or returns an invalid IQN. An explicitly set iscsiIQNBase still overrides.