### PR TITLE
v1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ REGISTRY ?= quay.io/truenas_solutions
 DRIVER_IMAGE ?= $(REGISTRY)/truenas-csi
 OPERATOR_IMAGE ?= $(REGISTRY)/truenas-csi-operator
 BUNDLE_IMAGE ?= $(REGISTRY)/truenas-csi-operator-bundle
-VERSION ?= 1.1.2
+VERSION ?= 1.2.0
 IMG_TAG ?= v$(VERSION)
 
 # Go configuration

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean: ## Clean build artifacts
 	rm -rf bin/
 
 .PHONY: bump-version
-bump-version: ## Update all hardcoded version refs (e.g. make bump-version VERSION=1.1.3)
+bump-version: ## Update all hardcoded version refs (e.g. make bump-version VERSION=1.2.0)
 	@echo "Setting version to $(VERSION)"
 	sed -i 's/^VERSION ?= .*/VERSION ?= $(VERSION)/' Makefile operator/Makefile
 	sed -i 's#\(truenas-csi-operator:v\)[0-9][0-9.]*#\1$(VERSION)#' operator/config/manifests/bases/operator.clusterserviceversion.yaml

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ The default deployment manifest uses `/var/lib/kubelet` as the kubelet root dire
 | Distribution | Kubelet Path |
 |---|---|
 | Standard Kubernetes | `/var/lib/kubelet` (default) |
+| K3s | `/var/lib/kubelet` |
 | MicroK8s | `/var/snap/microk8s/common/var/lib/kubelet` |
-| K3s | `/var/lib/rancher/k3s/agent/kubelet` |
 
 > **Important:** The `kubelet-dir` `mountPath` must match the `hostPath`. If they differ, NFS mounts will succeed inside the CSI container but will not propagate to kubelet, causing pods to see local storage instead of NFS.
 

--- a/deploy/truenas-csi-driver.yaml
+++ b/deploy/truenas-csi-driver.yaml
@@ -269,7 +269,8 @@ spec:
           args:
             - "--csi-address=$(ADDRESS)"
             - "--v=5"
-            - "--feature-gates=Topology=true"
+            # No Topology feature gate: the driver reports no accessible topology,
+            # so there is nothing for the provisioner to constrain PVs by.
             - "--extra-create-metadata"
             - "--leader-election=true"
             - "--default-fstype=ext4"

--- a/deploy/truenas-csi-driver.yaml
+++ b/deploy/truenas-csi-driver.yaml
@@ -447,6 +447,8 @@ spec:
             - name: iscsi-lib
               mountPath: /var/lib/iscsi
               mountPropagation: Bidirectional
+            - name: connector-dir
+              mountPath: /var/lib/truenas-csi
             - name: host-root
               mountPath: /host
               mountPropagation: Bidirectional
@@ -521,6 +523,13 @@ spec:
         - name: iscsi-lib
           hostPath:
             path: /var/lib/iscsi
+            type: DirectoryOrCreate
+        # Per-volume connector files record the protocol and target of each staged
+        # volume. NodeUnstageVolume gets no publish context, so this state has to
+        # outlive the container.
+        - name: connector-dir
+          hostPath:
+            path: /var/lib/truenas-csi
             type: DirectoryOrCreate
         - name: host-root
           hostPath:

--- a/deploy/truenas-csi-driver.yaml
+++ b/deploy/truenas-csi-driver.yaml
@@ -371,7 +371,14 @@ spec:
           lifecycle:
             postStart:
               exec:
-                command: ["/bin/sh", "-c", "mkdir -p /run/lock/iscsi && mv /usr/sbin/iscsiadm /usr/sbin/iscsiadm.orig 2>/dev/null; printf '#!/bin/sh\\nnsenter --mount=/host/proc/1/ns/mnt -- /usr/sbin/iscsiadm \"$@\"\\n' > /usr/sbin/iscsiadm && chmod +x /usr/sbin/iscsiadm; nsenter --mount=/host/proc/1/ns/mnt -- modprobe nvme_tcp 2>/dev/null || true; nsenter --mount=/host/proc/1/ns/mnt -- modprobe nvme_fabrics 2>/dev/null || true; test -x /usr/sbin/iscsiadm"]
+                # The shim replaces the container's bundled iscsiadm and re-execs the
+                # host's copy in the host mount namespace. The host binary is looked
+                # up on PATH, not at an absolute path: distributions disagree on where
+                # iscsiadm lives (/usr/sbin on Debian and RHEL, /usr/local/sbin on
+                # Talos), and naming a path makes execvp skip the search and fail with
+                # a bare exit 127. The modprobes are non-fatal because NVMe-oF is
+                # optional, so the hook's verdict is gated on the shim instead.
+                command: ["/bin/sh", "-c", "mkdir -p /run/lock/iscsi && mv /usr/sbin/iscsiadm /usr/sbin/iscsiadm.orig 2>/dev/null; printf '#!/bin/sh\\nexport PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin\\nexec nsenter --mount=/host/proc/1/ns/mnt -- iscsiadm \"$@\"\\n' > /usr/sbin/iscsiadm && chmod +x /usr/sbin/iscsiadm; nsenter --mount=/host/proc/1/ns/mnt -- modprobe nvme_tcp 2>/dev/null || true; nsenter --mount=/host/proc/1/ns/mnt -- modprobe nvme_fabrics 2>/dev/null || true; test -x /usr/sbin/iscsiadm"]
           securityContext:
             privileged: true
           args:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.1.2
+VERSION ?= 1.2.0
 
 # Git version information for ldflags injection
 GIT_VERSION := $(shell git describe --dirty --tags --always 2>/dev/null || echo "unknown")

--- a/operator/bundle/manifests/truenas-csi.clusterserviceversion.yaml
+++ b/operator/bundle/manifests/truenas-csi.clusterserviceversion.yaml
@@ -22,8 +22,8 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Storage
-    containerImage: quay.io/truenas_solutions/truenas-csi-operator@sha256:c17e440e429b856aa284457249b5aa52f3837d29ca73f24ec806ef913c1f97fa
-    createdAt: "2026-07-17T18:41:08Z"
+    containerImage: quay.io/truenas_solutions/truenas-csi-operator@sha256:dbd5d6735a2ecef382dd89d7fbfc44f474fd7bb73c19b4fb110e61ace7f733d3
+    createdAt: "2026-08-24T18:41:00Z"
     description: Deploys and manages the TrueNAS CSI driver for dynamic volume provisioning
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
@@ -39,10 +39,10 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     repository: https://github.com/truenas/truenas-csi
     support: TrueNAS
-  name: truenas-csi.v1.1.2
+  name: truenas-csi.v1.2.0
   namespace: placeholder
 spec:
-  replaces: truenas-csi.v1.1.1
+  replaces: truenas-csi.v1.1.2
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
@@ -544,8 +544,8 @@ spec:
                       - name: LIVENESS_PROBE_IMAGE
                         value: registry.k8s.io/sig-storage/livenessprobe@sha256:7fe80915b3cb9fb1d09dbd300a0682cafa8ab93947cd3ddc3e15a8250621bf24
                       - name: DRIVER_IMAGE
-                        value: quay.io/truenas_solutions/truenas-csi@sha256:24b5f98db445b1bd4d9eb4e0d57448ddec82a08a5f2d8c3267bf793096e60604
-                    image: quay.io/truenas_solutions/truenas-csi-operator@sha256:c17e440e429b856aa284457249b5aa52f3837d29ca73f24ec806ef913c1f97fa
+                        value: quay.io/truenas_solutions/truenas-csi@sha256:41f8182868c856bfa7a1a3f9415efb8249f2f2345a40ed69b8483f4edd964be8
+                    image: quay.io/truenas_solutions/truenas-csi-operator@sha256:dbd5d6735a2ecef382dd89d7fbfc44f474fd7bb73c19b4fb110e61ace7f733d3
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -646,9 +646,9 @@ spec:
     name: TrueNAS
     url: https://www.truenas.com
   relatedImages:
-    - image: quay.io/truenas_solutions/truenas-csi-operator@sha256:c17e440e429b856aa284457249b5aa52f3837d29ca73f24ec806ef913c1f97fa
+    - image: quay.io/truenas_solutions/truenas-csi-operator@sha256:dbd5d6735a2ecef382dd89d7fbfc44f474fd7bb73c19b4fb110e61ace7f733d3
       name: truenas-csi-operator
-    - image: quay.io/truenas_solutions/truenas-csi@sha256:24b5f98db445b1bd4d9eb4e0d57448ddec82a08a5f2d8c3267bf793096e60604
+    - image: quay.io/truenas_solutions/truenas-csi@sha256:41f8182868c856bfa7a1a3f9415efb8249f2f2345a40ed69b8483f4edd964be8
       name: truenas-csi
     - image: registry.k8s.io/sig-storage/csi-attacher@sha256:4f6b1289ffe62dbe3d2317dd938cd9dd3fb0a7c0088d505cde4effa1e0771dc2
       name: csi-attacher
@@ -662,4 +662,4 @@ spec:
       name: csi-snapshotter
     - image: registry.k8s.io/sig-storage/livenessprobe@sha256:7fe80915b3cb9fb1d09dbd300a0682cafa8ab93947cd3ddc3e15a8250621bf24
       name: livenessprobe
-  version: 1.1.2
+  version: 1.2.0

--- a/operator/config/manager/kustomization.yaml
+++ b/operator/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/truenas_solutions/truenas-csi-operator
-  newTag: v1.1.2
+  newTag: v1.2.0

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -79,7 +79,7 @@ spec:
         - name: LIVENESS_PROBE_IMAGE
           value: "registry.k8s.io/sig-storage/livenessprobe:v2.18.0"
         - name: DRIVER_IMAGE
-          value: "quay.io/truenas_solutions/truenas-csi:v1.1.2"
+          value: "quay.io/truenas_solutions/truenas-csi:v1.2.0"
         ports: []
         securityContext:
           allowPrivilegeEscalation: false

--- a/operator/config/manifests/bases/operator.clusterserviceversion.yaml
+++ b/operator/config/manifests/bases/operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
       ]
     capabilities: Full Lifecycle
     categories: Storage
-    containerImage: quay.io/truenas_solutions/truenas-csi-operator:v1.1.2
+    containerImage: quay.io/truenas_solutions/truenas-csi-operator:v1.2.0
     createdAt: "2026-01-20T00:00:00Z"
     description: Deploys and manages the TrueNAS CSI driver for dynamic volume provisioning
     features.operators.openshift.io/cnf: "false"

--- a/operator/internal/controller/constants.go
+++ b/operator/internal/controller/constants.go
@@ -67,6 +67,7 @@ const (
 	VolumeModulesDir      = "modules-dir"
 	VolumeISCSIDir        = "iscsi-dir"
 	VolumeISCSILib        = "iscsi-lib"
+	VolumeConnectorDir    = "connector-dir"
 	VolumeHostRoot        = "host-root"
 	VolumeHostFstab       = "host-fstab"
 )
@@ -80,8 +81,13 @@ const (
 	HostPathModulesDir      = "/lib/modules"
 	HostPathISCSIDir        = "/etc/iscsi"
 	HostPathISCSILib        = "/var/lib/iscsi"
-	HostPathRoot            = "/"
-	HostPathFstab           = "/etc/fstab"
+	// HostPathConnectorDir keeps the driver's per-volume connector files on the
+	// node. They record which protocol and target each staged volume uses, and
+	// NodeUnstageVolume has no publish context to fall back on, so a container
+	// restart must not take them with it.
+	HostPathConnectorDir = "/var/lib/truenas-csi"
+	HostPathRoot         = "/"
+	HostPathFstab        = "/etc/fstab"
 )
 
 // CSI socket paths

--- a/operator/internal/controller/constants.go
+++ b/operator/internal/controller/constants.go
@@ -152,6 +152,24 @@ const (
 const (
 	ISCSILockDir    = "/run/lock/iscsi"
 	ISCSIDaemonPath = "/usr/sbin/iscsid"
+
+	// ContainerISCSIAdmPath is where the node container's own iscsiadm lives, and
+	// so where the shim that forwards to the host's has to be written.
+	ContainerISCSIAdmPath = "/usr/sbin/iscsiadm"
+
+	// ISCSIAdmBinary is how the host's iscsiadm is invoked: by name, so it is found
+	// on PATH. Distributions disagree on where it lives (/usr/sbin on Debian and
+	// RHEL, /usr/local/sbin on Talos), and naming an absolute path makes execvp
+	// skip the PATH search and fail with a bare exit 127.
+	ISCSIAdmBinary = "iscsiadm"
+
+	// HostMountNamespace is the host's mount namespace as seen from the node
+	// container, which nsenter joins to reach the host's storage tooling.
+	HostMountNamespace = "/host/proc/1/ns/mnt"
+
+	// HostBinarySearchPath is the PATH host binaries are looked up on, set
+	// explicitly so the lookup does not depend on the container image's default.
+	HostBinarySearchPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 
 // Sidecar image environment variable names

--- a/operator/internal/controller/truenascsi_controller.go
+++ b/operator/internal/controller/truenascsi_controller.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -753,6 +754,33 @@ func (r *TrueNASCSIReconciler) buildControllerContainer(image string, logLevel i
 	}
 }
 
+// buildNodePostStartCommand returns the node container's postStart hook. It replaces
+// the container's bundled iscsiadm with a shim that runs the host's, so the driver
+// uses the host's iSCSI stack and cannot hit a container/host version mismatch, and
+// it loads the NVMe/TCP fabrics kernel modules (NVMe-oF has no host daemon, so
+// nvme-cli runs in-container and only needs the modules present).
+//
+// The modprobes run in the host mount namespace so the host's kmod handles
+// compressed (.ko.zst) modules, and are non-fatal: NVMe-oF is optional, so the hook's
+// verdict is gated on the iscsiadm shim instead.
+func buildNodePostStartCommand() []string {
+	// csi-lib-iscsi invokes a bare "iscsiadm", which resolves to this shim on the
+	// container's PATH. The shim then joins the host mount namespace and looks the
+	// real binary up on PATH there, rather than naming a path the host may not use.
+	shim := fmt.Sprintf(`#!/bin/sh\nexport PATH=%s\nexec nsenter --mount=%s -- %s "$@"\n`,
+		HostBinarySearchPath, HostMountNamespace, ISCSIAdmBinary)
+
+	steps := []string{
+		fmt.Sprintf("mkdir -p %s && mv %s %s.orig 2>/dev/null", ISCSILockDir, ContainerISCSIAdmPath, ContainerISCSIAdmPath),
+		fmt.Sprintf("printf '%s' > %s && chmod +x %s", shim, ContainerISCSIAdmPath, ContainerISCSIAdmPath),
+		fmt.Sprintf("nsenter --mount=%s -- modprobe nvme_tcp 2>/dev/null || true", HostMountNamespace),
+		fmt.Sprintf("nsenter --mount=%s -- modprobe nvme_fabrics 2>/dev/null || true", HostMountNamespace),
+		fmt.Sprintf("test -x %s", ContainerISCSIAdmPath),
+	}
+
+	return []string{"/bin/sh", "-c", strings.Join(steps, "; ")}
+}
+
 func (r *TrueNASCSIReconciler) buildNodeContainer(image string, logLevel int32, csi *csiv1alpha1.TrueNASCSI) corev1.Container {
 	return corev1.Container{
 		Name:            NodeContainerName,
@@ -769,20 +797,10 @@ func (r *TrueNASCSIReconciler) buildNodeContainer(image string, logLevel int32, 
 			fmt.Sprintf("--v=%d", logLevel),
 		},
 		Env: buildTrueNASEnvVars(csi),
-		// PostStart creates an iscsiadm wrapper that uses the host's iSCSI stack
-		// via nsenter (avoiding container/host iscsiadm version mismatches), and
-		// loads the NVMe/TCP fabrics kernel modules (NVMe-oF has no host daemon, so
-		// nvme-cli runs in-container; it only needs the modules loaded). The modprobes
-		// run in the host mount namespace via nsenter so the host kmod handles
-		// compressed (.ko.zst) modules, and are non-fatal — NVMe-oF is optional, so the
-		// hook's verdict is gated on the iscsiadm shim instead.
 		Lifecycle: &corev1.Lifecycle{
 			PostStart: &corev1.LifecycleHandler{
 				Exec: &corev1.ExecAction{
-					Command: []string{
-						"/bin/sh", "-c",
-						fmt.Sprintf("mkdir -p %s && mv /usr/sbin/iscsiadm /usr/sbin/iscsiadm.orig 2>/dev/null; printf '#!/bin/sh\\nnsenter --mount=/host/proc/1/ns/mnt -- /usr/sbin/iscsiadm \"$@\"\\n' > /usr/sbin/iscsiadm && chmod +x /usr/sbin/iscsiadm; nsenter --mount=/host/proc/1/ns/mnt -- modprobe nvme_tcp 2>/dev/null || true; nsenter --mount=/host/proc/1/ns/mnt -- modprobe nvme_fabrics 2>/dev/null || true; test -x /usr/sbin/iscsiadm", ISCSILockDir),
-					},
+					Command: buildNodePostStartCommand(),
 				},
 			},
 		},

--- a/operator/internal/controller/truenascsi_controller.go
+++ b/operator/internal/controller/truenascsi_controller.go
@@ -836,7 +836,8 @@ func (r *TrueNASCSIReconciler) buildProvisionerSidecar() corev1.Container {
 		Args: []string{
 			"--csi-address=/csi/csi.sock",
 			fmt.Sprintf("--v=%d", SidecarLogLevel),
-			"--feature-gates=Topology=true",
+			// No Topology feature gate: the driver reports no accessible topology,
+			// so there is nothing for the provisioner to constrain PVs by.
 			"--extra-create-metadata",
 			"--leader-election=true",
 			fmt.Sprintf("--default-fstype=%s", DefaultFSType),

--- a/operator/internal/controller/volumes.go
+++ b/operator/internal/controller/volumes.go
@@ -25,6 +25,7 @@ func buildNodeVolumes() []corev1.Volume {
 		hostPathVolume(VolumeModulesDir, HostPathModulesDir, &hostPathDirectory),
 		hostPathVolume(VolumeISCSIDir, HostPathISCSIDir, &hostPathDirectory),
 		hostPathVolume(VolumeISCSILib, HostPathISCSILib, &hostPathDirectoryOrCreate),
+		hostPathVolume(VolumeConnectorDir, HostPathConnectorDir, &hostPathDirectoryOrCreate),
 		hostPathVolume(VolumeHostRoot, HostPathRoot, &hostPathDirectory),
 		hostPathVolume(VolumeSocketDir, HostPathPluginDir, &hostPathDirectoryOrCreate),
 		hostPathVolume(VolumeHostFstab, HostPathFstab, &hostPathFileOrCreate),
@@ -68,6 +69,7 @@ func buildNodeVolumeMounts() []corev1.VolumeMount {
 		{Name: VolumeModulesDir, MountPath: "/lib/modules", ReadOnly: true},
 		{Name: VolumeISCSIDir, MountPath: "/etc/iscsi", MountPropagation: &mountPropagationBidirectional},
 		{Name: VolumeISCSILib, MountPath: "/var/lib/iscsi", MountPropagation: &mountPropagationBidirectional},
+		{Name: VolumeConnectorDir, MountPath: HostPathConnectorDir},
 		{Name: VolumeHostRoot, MountPath: "/host", MountPropagation: &mountPropagationBidirectional},
 		{Name: VolumeHostFstab, MountPath: "/etc/fstab"},
 	}

--- a/operator/internal/controller/volumes_test.go
+++ b/operator/internal/controller/volumes_test.go
@@ -1,6 +1,9 @@
 package controller
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // The driver's connector files record which protocol and target each staged volume
 // uses. NodeUnstageVolume gets no publish context to fall back on, so this state has
@@ -35,5 +38,47 @@ func TestNodeConnectorDirIsHostBacked(t *testing.T) {
 	}
 	if !mounted {
 		t.Errorf("node container does not mount %q", VolumeConnectorDir)
+	}
+}
+
+// The postStart hook's shim enters the host mount namespace and must look iscsiadm
+// up on PATH. Naming an absolute path makes execvp skip the search, so hosts that
+// install iscsiadm anywhere but /usr/sbin (Talos uses /usr/local/sbin) fail every
+// iSCSI login with a bare exit 127.
+func TestNodePostStartResolvesHostISCSIAdmOnPath(t *testing.T) {
+	command := buildNodePostStartCommand()
+	if len(command) != 3 {
+		t.Fatalf("postStart command = %v, want [/bin/sh -c script]", command)
+	}
+	script := command[2]
+
+	nsenter := "nsenter --mount=" + HostMountNamespace + " -- "
+	if !strings.Contains(script, nsenter+ISCSIAdmBinary+` "$@"`) {
+		t.Errorf("shim does not invoke the host's iscsiadm by name:\n%s", script)
+	}
+	if strings.Contains(script, nsenter+ContainerISCSIAdmPath) {
+		t.Errorf("shim names an absolute host path for iscsiadm:\n%s", script)
+	}
+	if !strings.Contains(script, "export PATH="+HostBinarySearchPath) {
+		t.Errorf("shim does not set the host binary search path:\n%s", script)
+	}
+
+	// The container's own iscsiadm is still backed up and replaced by the shim, and
+	// the shim being in place is what the hook succeeds or fails on.
+	for _, want := range []string{
+		"mv " + ContainerISCSIAdmPath + " " + ContainerISCSIAdmPath + ".orig",
+		"> " + ContainerISCSIAdmPath + " && chmod +x " + ContainerISCSIAdmPath,
+		"test -x " + ContainerISCSIAdmPath,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("postStart script is missing %q:\n%s", want, script)
+		}
+	}
+
+	// NVMe-oF is optional, so its modprobes must not decide the hook's verdict.
+	for _, mod := range []string{"nvme_tcp", "nvme_fabrics"} {
+		if !strings.Contains(script, "modprobe "+mod+" 2>/dev/null || true") {
+			t.Errorf("modprobe of %s is not tolerant of failure:\n%s", mod, script)
+		}
 	}
 }

--- a/operator/internal/controller/volumes_test.go
+++ b/operator/internal/controller/volumes_test.go
@@ -1,0 +1,39 @@
+package controller
+
+import "testing"
+
+// The driver's connector files record which protocol and target each staged volume
+// uses. NodeUnstageVolume gets no publish context to fall back on, so this state has
+// to be backed by a host path: keeping it in the container's writable layer means a
+// csi-node restart strands every volume staged on that node.
+func TestNodeConnectorDirIsHostBacked(t *testing.T) {
+	var volume, mounted bool
+
+	for _, v := range buildNodeVolumes() {
+		if v.Name != VolumeConnectorDir {
+			continue
+		}
+		if v.HostPath == nil {
+			t.Fatalf("volume %q is not a host path", VolumeConnectorDir)
+		}
+		if v.HostPath.Path != HostPathConnectorDir {
+			t.Errorf("volume %q host path = %q, want %q", VolumeConnectorDir, v.HostPath.Path, HostPathConnectorDir)
+		}
+		volume = true
+	}
+	if !volume {
+		t.Errorf("node pod has no %q volume", VolumeConnectorDir)
+	}
+
+	for _, m := range buildNodeVolumeMounts() {
+		if m.Name == VolumeConnectorDir {
+			if m.MountPath != HostPathConnectorDir {
+				t.Errorf("volume %q mount path = %q, want %q", VolumeConnectorDir, m.MountPath, HostPathConnectorDir)
+			}
+			mounted = true
+		}
+	}
+	if !mounted {
+		t.Errorf("node container does not mount %q", VolumeConnectorDir)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,6 +40,16 @@ const (
 	rpcErrCodeNotFound       = -6 // ENOENT - resource not found
 	rpcErrCodeConnectionLost = -1 // Internal error for connection loss
 
+	// TrueNAS reports method call errors with a generic JSON-RPC code and carries the
+	// real errno in the error's data, so an expired session is identified by these
+	// rather than by the RPC code.
+	truenasErrnoNotAuthenticated = 207 // middlewared ErrnoMixin.ENOTAUTHENTICATED
+	errnameNotAuthenticated      = "ENOTAUTHENTICATED"
+
+	// API methods called directly by the client
+	methodCorePing            = "core.ping"
+	methodAuthLoginWithAPIKey = "auth.login_with_api_key"
+
 	// Logging verbosity levels (for logr.Logger.V())
 	// V(0) - Always logged (critical errors, startup/shutdown)
 	// V(1) - General operational info (connection events, reconnection)
@@ -146,6 +156,35 @@ func IsNotFoundError(err error) bool {
 		}
 	}
 	return false
+}
+
+// IsNotAuthenticatedError reports whether err indicates the TrueNAS session is no
+// longer authenticated. The appliance can expire a session while the WebSocket stays
+// open, in which case every call fails this way until the client re-authenticates.
+func IsNotAuthenticatedError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var rpcErr *RPCError
+	if !errors.As(err, &rpcErr) {
+		return false
+	}
+
+	// TrueNAS nests the errno and its name in the error's data.
+	if len(rpcErr.Data) > 0 {
+		var data struct {
+			Error   int    `json:"error"`
+			Errname string `json:"errname"`
+		}
+		if err := json.Unmarshal(rpcErr.Data, &data); err == nil {
+			if data.Error == truenasErrnoNotAuthenticated || data.Errname == errnameNotAuthenticated {
+				return true
+			}
+		}
+	}
+
+	// Fall back to the message for API shapes that do not populate data.
+	return strings.Contains(strings.ToUpper(rpcErr.Message), errnameNotAuthenticated)
 }
 
 // request represents a JSON-RPC request.
@@ -311,7 +350,7 @@ func (c *Client) dial(ctx context.Context) error {
 
 	authReq := request{
 		ID:      c.nextID.Add(1),
-		Method:  "auth.login_with_api_key",
+		Method:  methodAuthLoginWithAPIKey,
 		Params:  []string{c.config.APIKey},
 		JSONRPC: jsonRPCVersion,
 	}
@@ -409,22 +448,32 @@ func (c *Client) pingLoop(conn *websocket.Conn, done chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
+			// Ping with an API call rather than a WebSocket protocol ping: a protocol
+			// ping keeps the socket alive but never exercises the session, so an
+			// expired session would go unnoticed until a user request failed. This
+			// both keeps the session active and detects an expired one.
 			pingCtx, cancel := context.WithTimeout(context.Background(), defaultPingTimeout)
-			err := conn.Ping(pingCtx)
+			err := c.callOn(pingCtx, conn, methodCorePing, nil, nil)
 			cancel()
 
-			if err != nil {
-				select {
-				case <-done:
-					return
-				default:
-					c.log.V(logLevelInfo).Info("TrueNAS ping failed - connection lost", "error", err)
-					c.handleDisconnect(conn)
-					return
-				}
-			} else {
+			if err == nil {
 				c.log.V(logLevelDebug).Info("TrueNAS ping successful")
+				continue
 			}
+
+			select {
+			case <-done:
+				return
+			default:
+			}
+
+			if IsNotAuthenticatedError(err) {
+				c.log.Info("TrueNAS session is no longer authenticated, reconnecting to re-authenticate")
+			} else {
+				c.log.V(logLevelInfo).Info("TrueNAS ping failed - connection lost", "error", err)
+			}
+			c.handleDisconnect(conn)
+			return
 		}
 	}
 }
@@ -543,6 +592,8 @@ func (c *Client) Call(ctx context.Context, method string, params, result any) er
 	}
 	defer c.callSem.Release(1)
 
+	reauthenticated := false
+
 	for {
 		c.connMu.RLock()
 		conn := c.conn
@@ -565,6 +616,20 @@ func (c *Client) Call(ctx context.Context, method string, params, result any) er
 			c.log.V(logLevelInfo).Info("Retrying after connection loss", "method", method)
 			if waitErr := c.waitForConnection(ctx); waitErr != nil {
 				return err // Return original error if we can't reconnect in time
+			}
+			continue
+		}
+
+		// The appliance can expire the session while the socket stays healthy, which
+		// leaves every subsequent call failing. Dropping the connection makes the
+		// reconnect loop dial again, and dial re-authenticates. Retry only once so a
+		// genuinely rejected API key surfaces instead of looping.
+		if !reauthenticated && IsNotAuthenticatedError(err) {
+			reauthenticated = true
+			c.log.Info("TrueNAS session is no longer authenticated, reconnecting", "method", method)
+			c.handleDisconnect(conn)
+			if waitErr := c.waitForConnection(ctx); waitErr != nil {
+				return err // Return original error if we can't re-authenticate in time
 			}
 			continue
 		}
@@ -681,5 +746,5 @@ func (c *Client) Close() error {
 
 // Ping checks if the server is responsive by calling core.ping.
 func (c *Client) Ping(ctx context.Context) error {
-	return c.Call(ctx, "core.ping", nil, nil)
+	return c.Call(ctx, methodCorePing, nil, nil)
 }

--- a/pkg/client/integration_test.go
+++ b/pkg/client/integration_test.go
@@ -146,6 +146,49 @@ func TestIntegration_Ping(t *testing.T) {
 	}
 }
 
+// The keepalive loop pings with an API call so it also exercises the session, not
+// just the socket. Verify the appliance accepts those pings and the connection
+// survives several of them.
+func TestIntegration_KeepAlive(t *testing.T) {
+	url := os.Getenv("TRUENAS_URL")
+	apiKey := os.Getenv("TRUENAS_API_KEY")
+	insecure := os.Getenv("TRUENAS_INSECURE_SKIP_VERIFY") != "false"
+
+	var tlsConfig *tls.Config
+	if insecure {
+		tlsConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	const pingInterval = 1 * time.Second
+
+	client := New(Config{
+		URL:          url,
+		APIKey:       apiKey,
+		TLSConfig:    tlsConfig,
+		CallTimeout:  30 * time.Second,
+		PingInterval: pingInterval,
+	})
+	defer client.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := client.Connect(ctx); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	// Let several keepalive pings run. A failing ping would drop the connection.
+	time.Sleep(3*pingInterval + 500*time.Millisecond)
+
+	if !client.Connected() {
+		t.Fatal("connection did not survive the keepalive pings")
+	}
+
+	if err := client.Ping(ctx); err != nil {
+		t.Fatalf("call after keepalive pings failed: %v", err)
+	}
+}
+
 // =============================================================================
 // Dataset Tests
 // =============================================================================

--- a/pkg/client/reauth_test.go
+++ b/pkg/client/reauth_test.go
@@ -1,0 +1,152 @@
+package client
+
+import (
+	"encoding/json"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// notAuthenticatedError mirrors what TrueNAS returns once a session is no longer
+// authenticated: a generic method-call code with the errno carried in the data.
+func notAuthenticatedError() *RPCError {
+	return &RPCError{
+		Code:    -32001,
+		Message: "Method call error",
+		Data:    json.RawMessage(`{"error": 207, "errname": "ENOTAUTHENTICATED", "reason": "[ENOTAUTHENTICATED] Not authenticated"}`),
+	}
+}
+
+func TestIsNotAuthenticatedError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"non-RPC error", errors.New("boom"), false},
+		{"appliance payload", notAuthenticatedError(), true},
+		{
+			name: "errno only",
+			err:  &RPCError{Code: -32001, Message: "Method call error", Data: json.RawMessage(`{"error": 207}`)},
+			want: true,
+		},
+		{
+			name: "errname only",
+			err:  &RPCError{Code: -32001, Message: "Method call error", Data: json.RawMessage(`{"errname": "ENOTAUTHENTICATED"}`)},
+			want: true,
+		},
+		{
+			name: "message fallback when data is absent",
+			err:  &RPCError{Code: -32001, Message: "[ENOTAUTHENTICATED] Not authenticated"},
+			want: true,
+		},
+		{
+			name: "different errno is not an auth failure",
+			err:  &RPCError{Code: -32001, Message: "Method call error", Data: json.RawMessage(`{"error": 2, "errname": "ENOENT"}`)},
+			want: false,
+		},
+		{
+			name: "connection lost is not an auth failure",
+			err:  &RPCError{Code: rpcErrCodeConnectionLost, Message: "connection lost"},
+			want: false,
+		},
+		{
+			name: "unparsable data falls back to the message",
+			err:  &RPCError{Code: -32001, Message: "Method call error", Data: json.RawMessage(`not json`)},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotAuthenticatedError(tt.err); got != tt.want {
+				t.Errorf("IsNotAuthenticatedError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// newReauthTestClient returns a client that reconnects quickly, so the retry path
+// completes well inside the test timeout.
+func newReauthTestClient(t *testing.T, mock *MockTrueNASServer) *Client {
+	t.Helper()
+	client := New(Config{
+		URL:          mock.URL,
+		APIKey:       "test-api-key",
+		CallTimeout:  testTimeout,
+		PingInterval: 1 * time.Hour, // exercise the Call path, not the ping loop
+		ReconnectMin: 10 * time.Millisecond,
+		ReconnectMax: 50 * time.Millisecond,
+	})
+	if err := client.Connect(testContext(t)); err != nil {
+		t.Fatalf("failed to connect: %v", err)
+	}
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+// An expired session leaves the socket healthy, so the client must notice the
+// error itself, reconnect to re-authenticate, and retry the call.
+func TestCall_ReconnectsWhenSessionExpired(t *testing.T) {
+	mock := NewMockTrueNASServer()
+	defer mock.Close()
+
+	var calls atomic.Int32
+	mock.SetResponseFunc(func(method string, _ json.RawMessage) MockResponse {
+		if method != "pool.dataset.query" {
+			return MockResponse{Result: nil}
+		}
+		if calls.Add(1) == 1 {
+			return MockResponse{Error: notAuthenticatedError()}
+		}
+		return MockResponse{Result: []string{"tank"}}
+	})
+
+	client := newReauthTestClient(t, mock)
+	connectionsBefore := mock.ConnectionCount()
+
+	var result []string
+	if err := client.Call(testContext(t), "pool.dataset.query", []any{}, &result); err != nil {
+		t.Fatalf("Call should have recovered from the expired session, got: %v", err)
+	}
+
+	if len(result) != 1 || result[0] != "tank" {
+		t.Errorf("result = %v, want [tank]", result)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("method was called %d times, want 2 (initial + retry)", got)
+	}
+	if mock.ConnectionCount() <= connectionsBefore {
+		t.Errorf("client did not reconnect: connection count stayed at %d", mock.ConnectionCount())
+	}
+}
+
+// A key that is genuinely rejected must surface instead of retrying forever.
+func TestCall_NotAuthenticatedRetriesOnlyOnce(t *testing.T) {
+	mock := NewMockTrueNASServer()
+	defer mock.Close()
+
+	var calls atomic.Int32
+	mock.SetResponseFunc(func(method string, _ json.RawMessage) MockResponse {
+		if method == "pool.dataset.query" {
+			calls.Add(1)
+			return MockResponse{Error: notAuthenticatedError()}
+		}
+		return MockResponse{Result: nil}
+	})
+
+	client := newReauthTestClient(t, mock)
+
+	err := client.Call(testContext(t), "pool.dataset.query", []any{}, nil)
+	if err == nil {
+		t.Fatal("expected the persistent auth error to be returned")
+	}
+	if !IsNotAuthenticatedError(err) {
+		t.Errorf("expected a not-authenticated error, got: %v", err)
+	}
+	if got := calls.Load(); got != 2 {
+		t.Errorf("method was called %d times, want 2 (initial + single retry)", got)
+	}
+}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -281,6 +281,26 @@ func (s *ControllerServer) validateStorageClassParameters(ctx context.Context, p
 	return nil
 }
 
+// idempotentVolumeResponse builds the CreateVolume response for a volume that
+// already exists.
+//
+// The requested content source is echoed back. The external-provisioner rejects a
+// source-backed request answered without one and calls DeleteVolume to clean up, so
+// omitting it destroys the very clone the CO just asked for, mid-publish. The source
+// is taken from the request rather than read back from the dataset's ZFS origin:
+// provisioned names are generated per PVC, so the same name is never reused for a
+// different source, and a promoted or copy-restored dataset has no origin to compare.
+func idempotentVolumeResponse(volumeID string, capacityBytes int64, volumeContext map[string]string, source *csi.VolumeContentSource) *csi.CreateVolumeResponse {
+	return &csi.CreateVolumeResponse{
+		Volume: &csi.Volume{
+			VolumeId:      volumeID,
+			CapacityBytes: capacityBytes,
+			VolumeContext: volumeContext,
+			ContentSource: source,
+		},
+	}
+}
+
 // CreateVolume creates a new volume on TrueNAS, either as an NFS share or iSCSI target.
 func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	ctx, cancel := withTimeout(ctx, defaultOperationTimeout)
@@ -331,6 +351,15 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 	}
 	volumeID := datasetPath
 
+	// Check block volume compatibility with protocol (NFS cannot back raw block).
+	// This validates the request, so it runs before the idempotency check below,
+	// which would otherwise answer an invalid request with a success.
+	for _, cap := range req.VolumeCapabilities {
+		if cap.GetBlock() != nil && protocol != ProtocolISCSI && protocol != ProtocolNVMeOF {
+			return nil, status.Error(codes.InvalidArgument, "block volume mode is not supported for NFS protocol")
+		}
+	}
+
 	existingDataset, err := s.driver.Client().GetDataset(ctx, datasetPath)
 	if err == nil && existingDataset != nil {
 		// Volume already exists - check if compatible (idempotency)
@@ -365,55 +394,26 @@ func (s *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolu
 			returnedCapacity = requiredBytes
 		}
 
-		// For iSCSI ZVOLs, ensure the full iSCSI chain (target/extent/targetextent) exists.
-		// A previous CreateVolume may have created the ZVOL but failed before completing
-		// the iSCSI setup (e.g., due to a WebSocket connection drop).
-		if existingDataset.Type == datasetTypeVolume && protocol == ProtocolISCSI {
-			volCtx, err := s.ensureISCSIChain(ctx, volumeID, datasetPath, parameters)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to ensure iSCSI resources for existing volume: %v", err)
+		// For ZVOL-backed volumes, ensure the full protocol chain exists (iSCSI
+		// target/extent/targetextent, or NVMe-oF subsystem/namespace). A previous
+		// CreateVolume may have created the ZVOL but failed before completing that
+		// setup (e.g., due to a WebSocket connection drop).
+		volumeContext := parameters
+		if existingDataset.Type == datasetTypeVolume {
+			switch protocol {
+			case ProtocolISCSI:
+				volumeContext, err = s.ensureISCSIChain(ctx, volumeID, datasetPath, parameters)
+			case ProtocolNVMeOF:
+				volumeContext, err = s.ensureNVMeOFChain(ctx, volumeID, datasetPath, parameters)
 			}
-			s.driver.Log().V(LogLevelDebug).Info("Volume already exists, returning with iSCSI context", "volumeId", volumeID, "capacity", returnedCapacity)
-			return &csi.CreateVolumeResponse{
-				Volume: &csi.Volume{
-					VolumeId:      volumeID,
-					CapacityBytes: returnedCapacity,
-					VolumeContext: volCtx,
-				},
-			}, nil
-		}
-
-		// Same idempotent-repair for NVMe-oF ZVOLs.
-		if existingDataset.Type == datasetTypeVolume && protocol == ProtocolNVMeOF {
-			volCtx, err := s.ensureNVMeOFChain(ctx, volumeID, datasetPath, parameters)
 			if err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to ensure NVMe-oF resources for existing volume: %v", err)
+				return nil, status.Errorf(codes.Internal, "failed to ensure %s resources for existing volume: %v", protocol, err)
 			}
-			s.driver.Log().V(LogLevelDebug).Info("Volume already exists, returning with NVMe-oF context", "volumeId", volumeID, "capacity", returnedCapacity)
-			return &csi.CreateVolumeResponse{
-				Volume: &csi.Volume{
-					VolumeId:      volumeID,
-					CapacityBytes: returnedCapacity,
-					VolumeContext: volCtx,
-				},
-			}, nil
 		}
 
-		s.driver.Log().V(LogLevelDebug).Info("Volume already exists, returning existing volume", "volumeId", volumeID, "capacity", returnedCapacity)
-		return &csi.CreateVolumeResponse{
-			Volume: &csi.Volume{
-				VolumeId:      volumeID,
-				CapacityBytes: returnedCapacity,
-				VolumeContext: parameters,
-			},
-		}, nil
-	}
-
-	// Check block volume compatibility with protocol (NFS cannot back raw block)
-	for _, cap := range req.VolumeCapabilities {
-		if cap.GetBlock() != nil && protocol != ProtocolISCSI && protocol != ProtocolNVMeOF {
-			return nil, status.Error(codes.InvalidArgument, "block volume mode is not supported for NFS protocol")
-		}
+		s.driver.Log().V(LogLevelDebug).Info("Volume already exists, returning existing volume",
+			"volumeId", volumeID, "capacity", returnedCapacity, "protocol", protocol)
+		return idempotentVolumeResponse(volumeID, returnedCapacity, volumeContext, req.VolumeContentSource), nil
 	}
 
 	if req.VolumeContentSource != nil {
@@ -1258,48 +1258,6 @@ func (s *ControllerServer) createISCSIVolume(ctx context.Context, volumeID, data
 func (s *ControllerServer) createVolumeFromSource(ctx context.Context, req *csi.CreateVolumeRequest, volumeID, datasetPath, protocol string, parameters map[string]string) (*csi.CreateVolumeResponse, error) {
 	s.driver.Log().V(LogLevelDebug).Info("Creating volume from content source", "volumeId", volumeID)
 	contentSource := req.VolumeContentSource
-
-	// Idempotency check: if the target dataset already exists, return it
-	existingDataset, err := s.driver.Client().GetDataset(ctx, datasetPath)
-	if err == nil && existingDataset != nil {
-		s.driver.Log().V(LogLevelDebug).Info("Volume from content source already exists", "volumeId", volumeID)
-		capacityBytes := existingDataset.RefQuota
-		if isZVOLProtocol(protocol) && existingDataset.Volsize > 0 {
-			capacityBytes = existingDataset.Volsize
-		}
-
-		// For ZVOL-backed clones, ensure the full protocol chain exists. A previous
-		// CreateVolume may have cloned the ZVOL but failed before completing the
-		// iSCSI target/extent or NVMe-oF subsystem/namespace setup.
-		if existingDataset.Type == datasetTypeVolume && isZVOLProtocol(protocol) {
-			var volCtx map[string]string
-			if protocol == ProtocolNVMeOF {
-				volCtx, err = s.ensureNVMeOFChain(ctx, volumeID, datasetPath, parameters)
-			} else {
-				volCtx, err = s.ensureISCSIChain(ctx, volumeID, datasetPath, parameters)
-			}
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to ensure resources for existing clone: %v", err)
-			}
-			return &csi.CreateVolumeResponse{
-				Volume: &csi.Volume{
-					VolumeId:      volumeID,
-					CapacityBytes: capacityBytes,
-					VolumeContext: volCtx,
-					ContentSource: contentSource,
-				},
-			}, nil
-		}
-
-		return &csi.CreateVolumeResponse{
-			Volume: &csi.Volume{
-				VolumeId:      volumeID,
-				CapacityBytes: capacityBytes,
-				VolumeContext: parameters,
-				ContentSource: contentSource,
-			},
-		}, nil
-	}
 
 	switch {
 	case contentSource.GetSnapshot() != nil:

--- a/pkg/driver/controller_idempotency_test.go
+++ b/pkg/driver/controller_idempotency_test.go
@@ -1,0 +1,67 @@
+package driver
+
+import (
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+)
+
+// A repeated CreateVolume for a snapshot- or volume-backed request must echo the
+// content source. The external-provisioner rejects a source-backed request answered
+// without one and calls DeleteVolume to clean up, which deletes the clone it just
+// asked for while the CO is already publishing it.
+func TestIdempotentVolumeResponse_EchoesContentSource(t *testing.T) {
+	snapshotSource := &csi.VolumeContentSource{
+		Type: &csi.VolumeContentSource_Snapshot{
+			Snapshot: &csi.VolumeContentSource_SnapshotSource{SnapshotId: "tank/vol@snap-1"},
+		},
+	}
+	volumeSource := &csi.VolumeContentSource{
+		Type: &csi.VolumeContentSource_Volume{
+			Volume: &csi.VolumeContentSource_VolumeSource{VolumeId: "tank/pvc-source"},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		source *csi.VolumeContentSource
+	}{
+		{"snapshot source", snapshotSource},
+		{"volume source", volumeSource},
+		{"no source", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			volumeContext := map[string]string{PublishContextProtocol: ProtocolISCSI}
+			resp := idempotentVolumeResponse("tank/pvc-abc", 5*GiB, volumeContext, tt.source)
+
+			if resp.Volume.VolumeId != "tank/pvc-abc" {
+				t.Errorf("VolumeId = %q, want %q", resp.Volume.VolumeId, "tank/pvc-abc")
+			}
+			if resp.Volume.CapacityBytes != 5*GiB {
+				t.Errorf("CapacityBytes = %d, want %d", resp.Volume.CapacityBytes, 5*GiB)
+			}
+			if resp.Volume.VolumeContext[PublishContextProtocol] != ProtocolISCSI {
+				t.Errorf("VolumeContext = %v, want the protocol preserved", resp.Volume.VolumeContext)
+			}
+
+			if tt.source == nil {
+				if resp.Volume.ContentSource != nil {
+					t.Errorf("ContentSource = %v, want none for a sourceless request", resp.Volume.ContentSource)
+				}
+				return
+			}
+
+			if resp.Volume.ContentSource == nil {
+				t.Fatal("ContentSource is missing, the provisioner would delete this volume")
+			}
+			if got, want := resp.Volume.ContentSource.GetSnapshot().GetSnapshotId(), tt.source.GetSnapshot().GetSnapshotId(); got != want {
+				t.Errorf("snapshot ID = %q, want %q", got, want)
+			}
+			if got, want := resp.Volume.ContentSource.GetVolume().GetVolumeId(), tt.source.GetVolume().GetVolumeId(); got != want {
+				t.Errorf("source volume ID = %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -770,13 +770,9 @@ func (d *Driver) initializeCapabilities() {
 				},
 			},
 		},
-		{
-			Type: &csi.PluginCapability_Service_{
-				Service: &csi.PluginCapability_Service{
-					Type: csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS,
-				},
-			},
-		},
+		// VOLUME_ACCESSIBILITY_CONSTRAINTS is deliberately absent: TrueNAS storage is
+		// network-attached and reachable from every node, so no volume is bound to a
+		// subset of them. See NodeGetInfo.
 		{
 			Type: &csi.PluginCapability_VolumeExpansion_{
 				VolumeExpansion: &csi.PluginCapability_VolumeExpansion{

--- a/pkg/driver/iscsi.go
+++ b/pkg/driver/iscsi.go
@@ -3,9 +3,11 @@ package driver
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -26,12 +28,13 @@ const (
 	paramMultipathEnabled   = "iscsi.multipathEnabled"
 	paramPersistentSessions = "iscsi.persistentSessions"
 
-	// Directory for storing csi-lib-iscsi connector files
-	connectorDir = "/var/lib/truenas-csi/connectors"
-
 	// iSCSI connection settings
 	iscsiRetryCount    = 10 // number of login attempts
 	iscsiCheckInterval = 1  // seconds between retries
+
+	// iscsiadmExitNoObjsFound is iscsiadm's ISCSI_ERR_NO_OBJS_FOUND: the record or
+	// session asked about does not exist.
+	iscsiadmExitNoObjsFound = 21
 
 	// Filesystem types
 	fsTypeXFS = "xfs"
@@ -40,6 +43,13 @@ const (
 	mountOptionNouuid = "nouuid"
 	mountOptionBind   = "bind"
 )
+
+// connectorDir holds the per-volume connector files for iSCSI and NVMe-oF. It must
+// be backed by a host path in the node plugin's pod spec: it records which protocol
+// and target each staged volume uses, and NodeUnstageVolume gets no publish context
+// to fall back on, so losing it on a container restart strands staged volumes (see
+// handlerForVolume for the recovery path). Overridable in tests.
+var connectorDir = "/var/lib/truenas-csi/connectors"
 
 // ISCSIHandler implements the ProtocolHandler interface for iSCSI volumes
 type ISCSIHandler struct {
@@ -260,8 +270,7 @@ func (h *ISCSIHandler) Unstage(ctx context.Context, req *UnstageRequest) error {
 		if os.IsNotExist(err) {
 			h.log.V(LogLevelDebug).Info("Staging path does not exist, considering unstaged", "stagingPath", req.StagingPath)
 			// Still try to disconnect iSCSI and cleanup connector
-			h.cleanupISCSISession(req.VolumeID)
-			return nil
+			return h.cleanupISCSISession(req.VolumeID)
 		}
 		return fmt.Errorf("failed to check mount point: %w", err)
 	}
@@ -274,7 +283,9 @@ func (h *ISCSIHandler) Unstage(ctx context.Context, req *UnstageRequest) error {
 	}
 
 	// Disconnect iSCSI session and cleanup
-	h.cleanupISCSISession(req.VolumeID)
+	if err := h.cleanupISCSISession(req.VolumeID); err != nil {
+		return err
+	}
 
 	// Remove staging directory
 	os.Remove(req.StagingPath)
@@ -283,11 +294,16 @@ func (h *ISCSIHandler) Unstage(ctx context.Context, req *UnstageRequest) error {
 	return nil
 }
 
-// cleanupISCSISession disconnects the iSCSI session and removes the connector file
-func (h *ISCSIHandler) cleanupISCSISession(volumeID string) {
+// cleanupISCSISession logs out of the iSCSI session and removes the connector file.
+//
+// The connector file is the only record of the volume's protocol and target, so it
+// is kept when logout fails: removing it would leave later unstage attempts unable
+// to recognize the volume as iSCSI. The failure is returned rather than swallowed so
+// the CSI call is retried instead of reporting a teardown that did not happen.
+func (h *ISCSIHandler) cleanupISCSISession(volumeID string) error {
 	cpath := connectorPath(volumeID)
 	if _, err := os.Stat(cpath); err != nil {
-		return // No connector file, nothing to clean up
+		return nil // No connector file, nothing to clean up
 	}
 
 	// Try to load connector - GetConnectorFromFile may fail validation if
@@ -301,12 +317,47 @@ func (h *ISCSIHandler) cleanupISCSISession(volumeID string) {
 	}
 
 	if connector != nil && connector.TargetIqn != "" {
-		iscsilib.Disconnect(connector.TargetIqn, connector.TargetPortals)
+		if err := logoutISCSITarget(connector.TargetIqn, connector.TargetPortals); err != nil {
+			return fmt.Errorf("failed to log out of iSCSI target %s: %w", connector.TargetIqn, err)
+		}
 		h.log.V(LogLevelDebug).Info("Disconnected from iSCSI target", "targetIqn", connector.TargetIqn)
 	}
 
 	// Remove connector file
-	os.Remove(cpath)
+	if err := os.Remove(cpath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove connector file %s: %w", cpath, err)
+	}
+	return nil
+}
+
+// logoutISCSITarget logs out of every portal of a target and drops its node
+// database entry. csi-lib-iscsi's Disconnect helper does the same work but discards
+// every error and gives the caller no way to tell a completed logout from a failed
+// one, so its finer-grained calls are used directly here. Overridable in tests.
+var logoutISCSITarget = func(targetIQN string, portals []string) error {
+	for _, portal := range portals {
+		// Node records are keyed by portal address; matching without the port
+		// covers records written for a non-default port.
+		host := portal
+		if h, _, err := net.SplitHostPort(portal); err == nil {
+			host = h
+		}
+		if err := iscsilib.Logout(targetIQN, host); err != nil && !isNoISCSIObjectsFound(err) {
+			return fmt.Errorf("logout from portal %s failed: %w", portal, err)
+		}
+	}
+
+	if err := iscsilib.DeleteDBEntry(targetIQN); err != nil && !isNoISCSIObjectsFound(err) {
+		return fmt.Errorf("removing the node database entry failed: %w", err)
+	}
+	return nil
+}
+
+// isNoISCSIObjectsFound reports whether an iscsiadm call failed only because what it
+// was asked about is not present, which makes logout idempotent.
+func isNoISCSIObjectsFound(err error) bool {
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && exitErr.ExitCode() == iscsiadmExitNoObjsFound
 }
 
 // readConnectorDirect reads a connector file without validation

--- a/pkg/driver/iscsi.go
+++ b/pkg/driver/iscsi.go
@@ -197,7 +197,7 @@ func (h *ISCSIHandler) Stage(ctx context.Context, req *StageRequest) (*StageResu
 	h.log.V(LogLevelDebug).Info("Connecting to iSCSI target", "portal", config.TargetPortal, "iqn", config.TargetIQN, "lun", config.LUN)
 	devicePath, err := iscsilib.Connect(*connector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to iSCSI target %s at %s: %w", config.TargetIQN, config.TargetPortal, err)
+		return nil, fmt.Errorf("failed to connect to iSCSI target %s at %s: %w", config.TargetIQN, config.TargetPortal, withCommandOutput(err))
 	}
 
 	h.log.V(LogLevelDebug).Info("iSCSI connected", "device", devicePath)
@@ -343,12 +343,12 @@ var logoutISCSITarget = func(targetIQN string, portals []string) error {
 			host = h
 		}
 		if err := iscsilib.Logout(targetIQN, host); err != nil && !isNoISCSIObjectsFound(err) {
-			return fmt.Errorf("logout from portal %s failed: %w", portal, err)
+			return fmt.Errorf("logout from portal %s failed: %w", portal, withCommandOutput(err))
 		}
 	}
 
 	if err := iscsilib.DeleteDBEntry(targetIQN); err != nil && !isNoISCSIObjectsFound(err) {
-		return fmt.Errorf("removing the node database entry failed: %w", err)
+		return fmt.Errorf("removing the node database entry failed: %w", withCommandOutput(err))
 	}
 	return nil
 }
@@ -358,6 +358,17 @@ var logoutISCSITarget = func(targetIQN string, portals []string) error {
 func isNoISCSIObjectsFound(err error) bool {
 	var exitErr *exec.ExitError
 	return errors.As(err, &exitErr) && exitErr.ExitCode() == iscsiadmExitNoObjsFound
+}
+
+// withCommandOutput appends a failed command's stderr to its error. csi-lib-iscsi
+// surfaces only the exit status, which reduces a plain diagnosis - an iscsiadm the
+// host cannot run, say - to an opaque "exit status 127" with nothing to act on.
+func withCommandOutput(err error) error {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return fmt.Errorf("%w: %s", err, strings.TrimSpace(string(exitErr.Stderr)))
+	}
+	return err
 }
 
 // readConnectorDirect reads a connector file without validation

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -469,21 +469,21 @@ func (s *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpub
 	return &csi.NodeUnpublishVolumeResponse{}, nil
 }
 
-// NodeGetInfo returns the node ID and topology information.
+// NodeGetInfo returns the node ID.
+//
+// No accessible topology is reported. TrueNAS storage is network-attached and every
+// protocol the driver speaks (NFS, iSCSI, NVMe-oF) is reachable from any node with
+// network access, so there is no per-node locality to encode. Reporting a segment
+// only lets the provisioner stamp node affinity onto a PV, and since a node label
+// holds one value per key, any volume whose segment does not match what the nodes
+// happen to advertise becomes permanently unschedulable. The driver does not
+// advertise VOLUME_ACCESSIBILITY_CONSTRAINTS for the same reason.
 func (s *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	s.driver.Log().V(LogLevelDebug).Info("NodeGetInfo called")
 
 	return &csi.NodeGetInfoResponse{
 		NodeId: s.driver.NodeID(),
 		// MaxVolumesPerNode: 0 means no limit
-		// No pool-based topology: TrueNAS storage (NFS/iSCSI/NVMe-oF) is
-		// network-attached and reachable from every node, so volumes must not be
-		// constrained to a pool's node label. Only the per-node key is advertised.
-		AccessibleTopology: &csi.Topology{
-			Segments: map[string]string{
-				"topology.truenas.io/node": s.driver.NodeID(),
-			},
-		},
 	}, nil
 }
 

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
+	"slices"
+	"strings"
 	"sync"
 	"syscall"
 
@@ -13,6 +16,19 @@ import (
 	"k8s.io/mount-utils"
 	"k8s.io/utils/exec"
 )
+
+const (
+	// Device path prefixes used to tell protocols apart from the mount table.
+	devicePrefixDev  = "/dev/"
+	devicePrefixNVMe = "/dev/nvme"
+
+	// statfsFlagReadOnly is ST_RDONLY from statfs(2), which the syscall package
+	// does not export.
+	statfsFlagReadOnly = 0x1
+)
+
+// statfs is syscall.Statfs; overridable in tests.
+var statfs = syscall.Statfs
 
 // NodeServer implements the CSI Node service
 type NodeServer struct {
@@ -97,16 +113,92 @@ func (s *NodeServer) getHandler(publishContext map[string]string) (ProtocolHandl
 }
 
 // handlerForVolume picks the protocol handler for Unstage/Expand, where no publish
-// context is available, by checking which connector file exists (NVMe first, then
-// iSCSI, defaulting to NFS).
-func (s *NodeServer) handlerForVolume(volumeID string) ProtocolHandler {
+// context is available. The connector file written at stage time is the primary
+// signal (NVMe first, then iSCSI).
+//
+// When no connector file exists the protocol is recovered from the mount at path.
+// Falling straight through to NFS is not safe: NFS Unstage is a no-op, so a block
+// volume whose connector file was lost would be reported as unstaged while its
+// staging mount and its session stayed in place, and the next stage would hand that
+// stale mount to workloads.
+func (s *NodeServer) handlerForVolume(volumeID, path string) ProtocolHandler {
 	if _, err := os.Stat(nvmeConnectorPath(volumeID)); err == nil {
 		return s.nvmeofHandler
 	}
 	if _, err := os.Stat(connectorPath(volumeID)); err == nil {
 		return s.iscsiHandler
 	}
+
+	if handler := s.handlerForMount(path); handler != nil {
+		s.driver.Log().Info("No connector file for volume, recovered the protocol from the mount",
+			"volumeId", volumeID, "path", path, "protocol", handler.Protocol())
+		return handler
+	}
+
+	s.driver.Log().V(LogLevelDebug).Info("No connector file and nothing mounted for volume, treating it as NFS",
+		"volumeId", volumeID, "path", path)
 	return s.nfsHandler
+}
+
+// handlerForMount identifies the protocol of whatever is mounted at path, or returns
+// nil when path is not mounted or the mount is not recognizable.
+func (s *NodeServer) handlerForMount(path string) ProtocolHandler {
+	if path == "" {
+		return nil
+	}
+
+	mounts, err := s.mounter.List()
+	if err != nil {
+		s.driver.Log().V(LogLevelDebug).Info("Failed to list mounts", "error", err)
+		return nil
+	}
+
+	// Paths can be mounted over; the last matching entry is the effective mount.
+	var handler ProtocolHandler
+	target := filepath.Clean(path)
+	for _, m := range mounts {
+		if filepath.Clean(m.Path) != target {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(m.Type, fsTypeNFS):
+			handler = s.nfsHandler
+		case strings.HasPrefix(m.Device, devicePrefixNVMe):
+			handler = s.nvmeofHandler
+		case strings.HasPrefix(m.Device, devicePrefixDev):
+			handler = s.iscsiHandler
+		}
+	}
+	return handler
+}
+
+// readOnlyRequested reports whether a volume capability asks for a read-only mount.
+func readOnlyRequested(capability *csi.VolumeCapability) bool {
+	switch capability.GetAccessMode().GetMode() {
+	case csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY,
+		csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY:
+		return true
+	}
+	return slices.Contains(capability.GetMount().GetMountFlags(), mountOptionReadOnly)
+}
+
+// unusableStagedMountReason reports why the mount already present at the staging
+// path cannot be reused, or "" when it can be.
+//
+// A mount that outlives a storage-side interruption is left either unresponsive or
+// permanently read-only (ext4 aborts to read-only on I/O error). Repairing the
+// filesystem on the appliance does not help while that mount is still in place: the
+// staged filesystem is never re-read, so every pod bind-mounted onto it keeps
+// failing with EROFS. Such a mount is re-staged instead of being reused.
+func unusableStagedMountReason(path string, readOnly bool) string {
+	var stat syscall.Statfs_t
+	if err := statfs(path, &stat); err != nil {
+		return fmt.Sprintf("staged filesystem is not responding: %v", err)
+	}
+	if !readOnly && stat.Flags&statfsFlagReadOnly != 0 {
+		return "staged filesystem is mounted read-only but read-write access was requested"
+	}
+	return ""
 }
 
 // validateVolumeCapability checks if the requested capability is supported
@@ -155,17 +247,8 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 		return nil, status.Errorf(codes.InvalidArgument, "unsupported volume capability: %v", err)
 	}
 
-	// Check if already staged (idempotency)
-	notMounted, err := s.mounter.IsLikelyNotMountPoint(req.StagingTargetPath)
-	if err != nil && !os.IsNotExist(err) {
-		return nil, status.Errorf(codes.Internal, "failed to check staging path: %v", err)
-	}
-	if !notMounted {
-		s.driver.Log().V(LogLevelDebug).Info("Volume already staged", "volumeId", req.VolumeId, "stagingTargetPath", req.StagingTargetPath)
-		return &csi.NodeStageVolumeResponse{}, nil
-	}
-
-	// Acquire volume lock using volumeID-stagingPath combination
+	// Acquire volume lock using volumeID-stagingPath combination. Taken before the
+	// idempotency check below, which may have to tear a broken mount back down.
 	lockKey := fmt.Sprintf("%s-%s", req.VolumeId, req.StagingTargetPath)
 	if !s.TryAcquireLock(lockKey) {
 		return nil, status.Errorf(codes.Aborted, "operation already in progress for volume %s", req.VolumeId)
@@ -177,6 +260,28 @@ func (s *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolu
 	handler, err := s.getHandler(req.PublishContext)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "failed to determine protocol: %v", err)
+	}
+
+	// Check if already staged (idempotency), but only reuse a mount that still
+	// works: a dead or read-only staging mount is silently inherited by every pod
+	// that publishes from it, so it is torn down and staged again instead.
+	notMounted, err := s.mounter.IsLikelyNotMountPoint(req.StagingTargetPath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, status.Errorf(codes.Internal, "failed to check staging path: %v", err)
+	}
+	if !notMounted {
+		reason := unusableStagedMountReason(req.StagingTargetPath, readOnlyRequested(req.VolumeCapability))
+		if reason == "" {
+			s.driver.Log().V(LogLevelDebug).Info("Volume already staged", "volumeId", req.VolumeId, "stagingTargetPath", req.StagingTargetPath)
+			return &csi.NodeStageVolumeResponse{}, nil
+		}
+
+		s.driver.Log().Info("Existing staging mount is unusable, staging it again",
+			"volumeId", req.VolumeId, "stagingTargetPath", req.StagingTargetPath, "reason", reason)
+		unstageReq := &UnstageRequest{VolumeID: req.VolumeId, StagingPath: req.StagingTargetPath}
+		if err := handler.Unstage(ctx, unstageReq); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to release the unusable staging mount: %v", err)
+		}
 	}
 
 	// Check if this is a block volume request
@@ -232,8 +337,9 @@ func (s *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstage
 	}
 	defer s.ReleaseLock(lockKey)
 
-	// No publish context here — pick the handler from the connector file.
-	handler := s.handlerForVolume(req.VolumeId)
+	// No publish context here — pick the handler from the connector file, or from
+	// the staging mount itself when the connector file is gone.
+	handler := s.handlerForVolume(req.VolumeId, req.StagingTargetPath)
 
 	// Build unstage request
 	unstageReq := &UnstageRequest{
@@ -461,9 +567,9 @@ func (s *NodeServer) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVo
 		capacityBytes = req.CapacityRange.RequiredBytes
 	}
 
-	// No publish context here — pick the handler from the connector file
-	// (expansion is a no-op for NFS).
-	handler := s.handlerForVolume(req.VolumeId)
+	// No publish context here — pick the handler from the connector file, or from
+	// the mount itself when the connector file is gone (expansion is a no-op for NFS).
+	handler := s.handlerForVolume(req.VolumeId, req.VolumePath)
 
 	expandReq := &ExpandRequest{
 		VolumeID:      req.VolumeId,

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -402,3 +402,36 @@ func TestWithCommandOutput(t *testing.T) {
 		t.Errorf("withCommandOutput() = %v, want the original error", got)
 	}
 }
+
+// TrueNAS storage is reachable from every node, so the driver must not report an
+// accessible topology. A reported segment becomes node affinity on the PV, and a
+// node label holds one value per key, so any volume whose segment does not match
+// what the nodes advertise can never be scheduled.
+func TestNodeGetInfo_ReportsNoTopology(t *testing.T) {
+	ns, _ := newTestNodeServer(t, nil)
+	ns.driver.nodeID = "worker-1"
+
+	resp, err := ns.NodeGetInfo(context.Background(), &csi.NodeGetInfoRequest{})
+	if err != nil {
+		t.Fatalf("NodeGetInfo() = %v", err)
+	}
+	if resp.NodeId != "worker-1" {
+		t.Errorf("NodeId = %q, want %q", resp.NodeId, "worker-1")
+	}
+	if resp.AccessibleTopology != nil {
+		t.Errorf("NodeGetInfo reported topology %v, want none", resp.AccessibleTopology.Segments)
+	}
+}
+
+// The plugin must not claim topology support while reporting no topology: the
+// combination is what lets the provisioner pin PVs to labels no node carries.
+func TestPluginCapabilities_ExcludeAccessibilityConstraints(t *testing.T) {
+	d := &Driver{}
+	d.initializeCapabilities()
+
+	for _, c := range d.pluginCaps {
+		if c.GetService().GetType() == csi.PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS {
+			t.Error("driver advertises VOLUME_ACCESSIBILITY_CONSTRAINTS but reports no topology")
+		}
+	}
+}

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -6,6 +6,7 @@ import (
 	osexec "os/exec"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"syscall"
 	"testing"
 
@@ -376,4 +377,28 @@ func exitError(t *testing.T, code int) error {
 		t.Fatalf("expected a non-zero exit for code %d", code)
 	}
 	return err
+}
+
+// csi-lib-iscsi reports only an exit status, so a host that cannot run iscsiadm
+// surfaced as a bare "exit status 127" with nothing to act on. The command's stderr
+// is what names the real problem.
+func TestWithCommandOutput(t *testing.T) {
+	cmd := osexec.Command("sh", "-c", "echo 'nsenter: failed to execute iscsiadm: No such file or directory' >&2; exit 127")
+	if _, err := cmd.Output(); err == nil {
+		t.Fatal("expected the command to fail")
+	} else {
+		enriched := withCommandOutput(err)
+		if !strings.Contains(enriched.Error(), "failed to execute iscsiadm") {
+			t.Errorf("stderr was not surfaced: %v", enriched)
+		}
+		if !strings.Contains(enriched.Error(), "exit status 127") {
+			t.Errorf("exit status was lost: %v", enriched)
+		}
+	}
+
+	// Errors that carry no command output are passed through untouched.
+	plain := syscall.EIO
+	if got := withCommandOutput(plain); got != plain {
+		t.Errorf("withCommandOutput() = %v, want the original error", got)
+	}
 }

--- a/pkg/driver/node_test.go
+++ b/pkg/driver/node_test.go
@@ -1,0 +1,379 @@
+package driver
+
+import (
+	"context"
+	"os"
+	osexec "os/exec"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/go-logr/logr"
+	"k8s.io/mount-utils"
+	"k8s.io/utils/exec"
+)
+
+// useTempConnectorDir points connectorDir at a scratch directory for the duration of
+// a test, so connector files can be created and inspected without touching the host.
+func useTempConnectorDir(t *testing.T) string {
+	t.Helper()
+	orig := connectorDir
+	connectorDir = t.TempDir()
+	t.Cleanup(func() { connectorDir = orig })
+	return connectorDir
+}
+
+// stubStatfs replaces the statfs call with one that reports the given flags, or an
+// error when statErr is non-nil.
+func stubStatfs(t *testing.T, flags int64, statErr error) {
+	t.Helper()
+	orig := statfs
+	statfs = func(path string, stat *syscall.Statfs_t) error {
+		if statErr != nil {
+			return statErr
+		}
+		stat.Flags = flags
+		return nil
+	}
+	t.Cleanup(func() { statfs = orig })
+}
+
+// newTestNodeServer builds a NodeServer backed by a fake mounter, with all three
+// protocol handlers wired to it.
+func newTestNodeServer(t *testing.T, mounts []mount.MountPoint) (*NodeServer, *mount.FakeMounter) {
+	t.Helper()
+	log := logr.Discard()
+	fake := mount.NewFakeMounter(mounts)
+	safe := &mount.SafeFormatAndMount{Interface: fake, Exec: exec.New()}
+
+	driver := &Driver{
+		log: log,
+		volumeCaps: []*csi.VolumeCapability_AccessMode{
+			{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+			{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY},
+		},
+	}
+
+	return &NodeServer{
+		driver:        driver,
+		mounter:       fake,
+		iscsiHandler:  &ISCSIHandler{mounter: safe, resizer: mount.NewResizeFs(safe.Exec), log: log},
+		nvmeofHandler: &NVMeOFHandler{mounter: safe, resizer: mount.NewResizeFs(safe.Exec), log: log},
+		nfsHandler:    NewNFSHandler(fake, log),
+	}, fake
+}
+
+// A connector file whose volume was staged before the connector directory was
+// persisted on the host is gone after a container restart. Unstage must still reach
+// the protocol's own handler: dispatching to NFS, whose Unstage does nothing, would
+// report success while leaving the mount and the session in place.
+func TestHandlerForVolume_RecoversProtocolFromMount(t *testing.T) {
+	useTempConnectorDir(t)
+	const stagingPath = "/var/lib/kubelet/plugins/kubernetes.io/csi/csi.truenas.io/abc/globalmount"
+
+	tests := []struct {
+		name     string
+		mount    *mount.MountPoint
+		expected string
+	}{
+		{
+			name:     "iSCSI block device",
+			mount:    &mount.MountPoint{Device: "/dev/sda", Path: stagingPath, Type: "ext4"},
+			expected: ProtocolISCSI,
+		},
+		{
+			name:     "multipath block device",
+			mount:    &mount.MountPoint{Device: "/dev/dm-3", Path: stagingPath, Type: "xfs"},
+			expected: ProtocolISCSI,
+		},
+		{
+			name:     "NVMe-oF namespace",
+			mount:    &mount.MountPoint{Device: "/dev/nvme0n1", Path: stagingPath, Type: "ext4"},
+			expected: ProtocolNVMeOF,
+		},
+		{
+			name:     "NFS export",
+			mount:    &mount.MountPoint{Device: "10.0.0.1:/mnt/tank/vol", Path: stagingPath, Type: "nfs4"},
+			expected: ProtocolNFS,
+		},
+		{
+			name:     "nothing mounted falls back to NFS",
+			mount:    nil,
+			expected: ProtocolNFS,
+		},
+		{
+			name:     "unrelated mount falls back to NFS",
+			mount:    &mount.MountPoint{Device: "/dev/sdb", Path: "/some/other/path", Type: "ext4"},
+			expected: ProtocolNFS,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mounts []mount.MountPoint
+			if tt.mount != nil {
+				mounts = []mount.MountPoint{*tt.mount}
+			}
+			ns, _ := newTestNodeServer(t, mounts)
+
+			if got := ns.handlerForVolume("tank/pvc-abc", stagingPath).Protocol(); got != tt.expected {
+				t.Errorf("handlerForVolume() protocol = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+// The connector file is authoritative when it exists, even if the mount table would
+// suggest something else.
+func TestHandlerForVolume_PrefersConnectorFile(t *testing.T) {
+	dir := useTempConnectorDir(t)
+	const (
+		volumeID    = "tank/pvc-abc"
+		stagingPath = "/var/lib/kubelet/staging/globalmount"
+	)
+
+	// An NFS-looking mount that must not win over an iSCSI connector file.
+	mounts := []mount.MountPoint{{Device: "10.0.0.1:/mnt/tank/vol", Path: stagingPath, Type: "nfs4"}}
+	ns, _ := newTestNodeServer(t, mounts)
+
+	if err := os.WriteFile(filepath.Join(dir, sanitizeISCSIVolumeID(volumeID)+".connector"), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("failed to write connector file: %v", err)
+	}
+	if got := ns.handlerForVolume(volumeID, stagingPath).Protocol(); got != ProtocolISCSI {
+		t.Errorf("handlerForVolume() protocol = %q, want %q", got, ProtocolISCSI)
+	}
+
+	// NVMe-oF wins over iSCSI when both connector files are present.
+	if err := os.WriteFile(nvmeConnectorPath(volumeID), []byte("{}"), 0o600); err != nil {
+		t.Fatalf("failed to write NVMe connector file: %v", err)
+	}
+	if got := ns.handlerForVolume(volumeID, stagingPath).Protocol(); got != ProtocolNVMeOF {
+		t.Errorf("handlerForVolume() protocol = %q, want %q", got, ProtocolNVMeOF)
+	}
+}
+
+func TestReadOnlyRequested(t *testing.T) {
+	mountCap := func(mode csi.VolumeCapability_AccessMode_Mode, flags ...string) *csi.VolumeCapability {
+		return &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{MountFlags: flags},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: mode},
+		}
+	}
+
+	tests := []struct {
+		name       string
+		capability *csi.VolumeCapability
+		want       bool
+	}{
+		{"single node writer", mountCap(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER), false},
+		{"single node reader only", mountCap(csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY), true},
+		{"multi node reader only", mountCap(csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY), true},
+		{"writer with ro mount flag", mountCap(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER, "ro"), true},
+		{"writer with other mount flags", mountCap(csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER, "noatime"), false},
+		{"block volume", &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Block{Block: &csi.VolumeCapability_BlockVolume{}},
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+		}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := readOnlyRequested(tt.capability); got != tt.want {
+				t.Errorf("readOnlyRequested() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnusableStagedMountReason(t *testing.T) {
+	tests := []struct {
+		name       string
+		flags      int64
+		statErr    error
+		readOnly   bool
+		wantReason bool
+	}{
+		{name: "healthy read-write mount"},
+		{name: "read-only mount when read-write was requested", flags: statfsFlagReadOnly, wantReason: true},
+		{name: "read-only mount when read-only was requested", flags: statfsFlagReadOnly, readOnly: true},
+		{name: "statfs failure", statErr: syscall.EIO, wantReason: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stubStatfs(t, tt.flags, tt.statErr)
+			reason := unusableStagedMountReason("/staging", tt.readOnly)
+			if (reason != "") != tt.wantReason {
+				t.Errorf("unusableStagedMountReason() = %q, want a reason: %v", reason, tt.wantReason)
+			}
+		})
+	}
+}
+
+// stageRequest builds a filesystem NodeStageVolume request for an iSCSI volume.
+func stageRequest(volumeID, stagingPath string) *csi.NodeStageVolumeRequest {
+	return &csi.NodeStageVolumeRequest{
+		VolumeId:          volumeID,
+		StagingTargetPath: stagingPath,
+		PublishContext:    map[string]string{PublishContextProtocol: ProtocolISCSI},
+		VolumeCapability: &csi.VolumeCapability{
+			AccessType: &csi.VolumeCapability_Mount{
+				Mount: &csi.VolumeCapability_MountVolume{FsType: DefaultFSType},
+			},
+			AccessMode: &csi.VolumeCapability_AccessMode{Mode: csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER},
+		},
+	}
+}
+
+// stagingDir creates a staging path that the fake mounter will accept as mounted.
+func stagingDir(t *testing.T) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "globalmount")
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		t.Fatalf("failed to create staging dir: %v", err)
+	}
+	// The fake mounter resolves symlinks before matching mount points.
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("failed to resolve staging dir: %v", err)
+	}
+	return resolved
+}
+
+func TestNodeStageVolume_ReusesHealthyMount(t *testing.T) {
+	useTempConnectorDir(t)
+	staging := stagingDir(t)
+	stubStatfs(t, 0, nil)
+
+	ns, fake := newTestNodeServer(t, []mount.MountPoint{{Device: "/dev/sda", Path: staging, Type: "ext4"}})
+
+	if _, err := ns.NodeStageVolume(context.Background(), stageRequest("tank/pvc-abc", staging)); err != nil {
+		t.Fatalf("NodeStageVolume() on a healthy mount should succeed, got: %v", err)
+	}
+	if len(fake.GetLog()) != 0 {
+		t.Errorf("a healthy staging mount must be left alone, got actions: %v", fake.GetLog())
+	}
+}
+
+// After a storage-side interruption the staging mount survives as a read-only,
+// aborted filesystem. Reusing it hands every pod an EROFS filesystem that no
+// appliance-side repair can fix, so stage must tear it down and mount again.
+func TestNodeStageVolume_RestagesUnusableMount(t *testing.T) {
+	useTempConnectorDir(t)
+	staging := stagingDir(t)
+	stubStatfs(t, statfsFlagReadOnly, nil)
+
+	ns, fake := newTestNodeServer(t, []mount.MountPoint{{Device: "/dev/sda", Path: staging, Type: "ext4"}})
+
+	// Staging cannot complete without a reachable target, but the request must get
+	// past the idempotency check rather than reporting the stale mount as staged.
+	if _, err := ns.NodeStageVolume(context.Background(), stageRequest("tank/pvc-abc", staging)); err == nil {
+		t.Fatal("NodeStageVolume() should not have reported the unusable mount as staged")
+	}
+
+	var unmounted bool
+	for _, action := range fake.GetLog() {
+		if action.Action == mount.FakeActionUnmount && action.Target == staging {
+			unmounted = true
+		}
+	}
+	if !unmounted {
+		t.Errorf("the unusable staging mount was not unmounted, actions: %v", fake.GetLog())
+	}
+}
+
+// A failed logout must not take the connector file with it: the file is the only
+// record that the volume is iSCSI, and losing it sends later unstage attempts to
+// the wrong handler.
+func TestCleanupISCSISession_KeepsConnectorWhenLogoutFails(t *testing.T) {
+	dir := useTempConnectorDir(t)
+	const volumeID = "tank/pvc-abc"
+
+	cpath := filepath.Join(dir, sanitizeISCSIVolumeID(volumeID)+".connector")
+	connector := `{"volume_name":"pvc-abc","target_iqn":"iqn.2000-01.io.truenas:pvc-abc","target_portal":["10.0.0.1:3260"]}`
+	if err := os.WriteFile(cpath, []byte(connector), 0o600); err != nil {
+		t.Fatalf("failed to write connector file: %v", err)
+	}
+
+	orig := logoutISCSITarget
+	logoutISCSITarget = func(string, []string) error { return syscall.EIO }
+	t.Cleanup(func() { logoutISCSITarget = orig })
+
+	handler := &ISCSIHandler{log: logr.Discard()}
+	if err := handler.cleanupISCSISession(volumeID); err == nil {
+		t.Fatal("cleanupISCSISession() should report the failed logout")
+	}
+	if _, err := os.Stat(cpath); err != nil {
+		t.Errorf("connector file was removed despite the failed logout: %v", err)
+	}
+}
+
+func TestCleanupISCSISession_RemovesConnectorOnSuccess(t *testing.T) {
+	dir := useTempConnectorDir(t)
+	const volumeID = "tank/pvc-abc"
+
+	cpath := filepath.Join(dir, sanitizeISCSIVolumeID(volumeID)+".connector")
+	connector := `{"volume_name":"pvc-abc","target_iqn":"iqn.2000-01.io.truenas:pvc-abc","target_portal":["10.0.0.1:3260"]}`
+	if err := os.WriteFile(cpath, []byte(connector), 0o600); err != nil {
+		t.Fatalf("failed to write connector file: %v", err)
+	}
+
+	var loggedOutIQN string
+	orig := logoutISCSITarget
+	logoutISCSITarget = func(iqn string, _ []string) error {
+		loggedOutIQN = iqn
+		return nil
+	}
+	t.Cleanup(func() { logoutISCSITarget = orig })
+
+	handler := &ISCSIHandler{log: logr.Discard()}
+	if err := handler.cleanupISCSISession(volumeID); err != nil {
+		t.Fatalf("cleanupISCSISession() = %v, want nil", err)
+	}
+	if loggedOutIQN != "iqn.2000-01.io.truenas:pvc-abc" {
+		t.Errorf("logged out of %q, want the connector's target IQN", loggedOutIQN)
+	}
+	if _, err := os.Stat(cpath); !os.IsNotExist(err) {
+		t.Errorf("connector file should have been removed, stat error: %v", err)
+	}
+}
+
+// No connector file means there is nothing to log out of, which must not be an error.
+func TestCleanupISCSISession_NoConnector(t *testing.T) {
+	useTempConnectorDir(t)
+
+	handler := &ISCSIHandler{log: logr.Discard()}
+	if err := handler.cleanupISCSISession("tank/pvc-missing"); err != nil {
+		t.Errorf("cleanupISCSISession() with no connector file = %v, want nil", err)
+	}
+}
+
+func TestIsNoISCSIObjectsFound(t *testing.T) {
+	noObjs := exitError(t, iscsiadmExitNoObjsFound)
+	otherFailure := exitError(t, 1)
+
+	if !isNoISCSIObjectsFound(noObjs) {
+		t.Errorf("exit %d should be treated as nothing to log out of", iscsiadmExitNoObjsFound)
+	}
+	if isNoISCSIObjectsFound(otherFailure) {
+		t.Error("exit 1 should be treated as a real failure")
+	}
+	if isNoISCSIObjectsFound(syscall.EIO) {
+		t.Error("a non-exit error should be treated as a real failure")
+	}
+}
+
+// exitError runs a command that exits with the given code and returns the resulting
+// error, so tests see the same error type iscsiadm failures arrive as.
+func exitError(t *testing.T, code int) error {
+	t.Helper()
+	err := osexec.Command("sh", "-c", "exit "+strconv.Itoa(code)).Run()
+	if err == nil {
+		t.Fatalf("expected a non-zero exit for code %d", code)
+	}
+	return err
+}

--- a/pkg/driver/nvmeof.go
+++ b/pkg/driver/nvmeof.go
@@ -397,8 +397,7 @@ func (h *NVMeOFHandler) Unstage(ctx context.Context, req *UnstageRequest) error 
 	notMounted, err := h.mounter.IsLikelyNotMountPoint(req.StagingPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			h.cleanupNVMeSession(ctx, req.VolumeID)
-			return nil
+			return h.cleanupNVMeSession(ctx, req.VolumeID)
 		}
 		return fmt.Errorf("failed to check mount point: %w", err)
 	}
@@ -409,7 +408,9 @@ func (h *NVMeOFHandler) Unstage(ctx context.Context, req *UnstageRequest) error 
 		}
 	}
 
-	h.cleanupNVMeSession(ctx, req.VolumeID)
+	if err := h.cleanupNVMeSession(ctx, req.VolumeID); err != nil {
+		return err
+	}
 	os.Remove(req.StagingPath)
 
 	h.log.V(LogLevelDebug).Info("NVMe-oF volume unstaged", "volumeId", req.VolumeID)
@@ -417,14 +418,43 @@ func (h *NVMeOFHandler) Unstage(ctx context.Context, req *UnstageRequest) error 
 }
 
 // cleanupNVMeSession disconnects the subsystem and removes the connector file.
-func (h *NVMeOFHandler) cleanupNVMeSession(ctx context.Context, volumeID string) {
+//
+// The connector file is the only record of the volume's protocol and subsystem, so
+// it is kept when the disconnect fails: removing it would leave later unstage
+// attempts unable to recognize the volume as NVMe-oF. The failure is returned rather
+// than swallowed so the CSI call is retried instead of reporting a teardown that did
+// not happen.
+func (h *NVMeOFHandler) cleanupNVMeSession(ctx context.Context, volumeID string) error {
 	info := h.loadConnector(volumeID)
-	if info != nil && info.SubNQN != "" {
+	// Disconnecting a subsystem that is not connected is an error in nvme-cli, so
+	// the check keeps repeated unstage attempts idempotent.
+	if info != nil && info.SubNQN != "" && nvmeSubsystemConnected(info.SubNQN) {
 		if err := h.nvmeDisconnect(ctx, info.SubNQN); err != nil {
-			h.log.V(LogLevelDebug).Info("Failed to disconnect NVMe-oF subsystem", "subnqn", info.SubNQN, "error", err)
+			return fmt.Errorf("failed to disconnect NVMe-oF subsystem %s: %w", info.SubNQN, err)
 		}
 	}
-	os.Remove(nvmeConnectorPath(volumeID))
+	if err := os.Remove(nvmeConnectorPath(volumeID)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove connector file: %w", err)
+	}
+	return nil
+}
+
+// nvmeSubsystemConnected reports whether any local controller is attached to subnqn.
+func nvmeSubsystemConnected(subnqn string) bool {
+	if subnqn == "" {
+		return false
+	}
+	entries, err := os.ReadDir(nvmeSysClassDir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		data, err := os.ReadFile(filepath.Join(nvmeSysClassDir, e.Name(), "subsysnqn"))
+		if err == nil && strings.TrimSpace(string(data)) == subnqn {
+			return true
+		}
+	}
+	return false
 }
 
 // Publish bind-mounts the staged volume (or block device) to the target path.


### PR DESCRIPTION
Community bug-fix batch, released as a minor version because the driver no longer
advertises the CSI topology capability and the deployment surface changed.

Fixes:
- #55: connector state is kept on the host via a new /var/lib/truenas-csi hostPath, so a csi-node restart no longer strands staged volumes. Unstage returns failures instead of silently succeeding, stage re-mounts a staging path left read-only or unresponsive, and a failed logout no longer deletes the connector file.
- #56: the host's iscsiadm is resolved on PATH rather than a hardcoded /usr/sbin/iscsiadm, and iSCSI errors carry the command's stderr.
- #57: no accessible topology is reported and VOLUME_ACCESSIBILITY_CONSTRAINTS is dropped, along with the csi-provisioner Topology feature gate.
- #58: idempotent CreateVolume responses return the requested content source.
- #54: the client detects an expired appliance session and reconnects.
- #53: corrected the k3s kubelet path in the README.

Release: version bumped to 1.2.0, OLM bundle regenerated with replaces: truenas-csi.v1.1.2,
and all three images built and pushed to quay.

Upgrade note: standalone deployments must re-apply deploy/truenas-csi-driver.yaml.
Bumping the image tag alone does not deliver the connector, iscsiadm, or topology fixes.
Operator deployments pick the changes up on the next reconcile.

Not yet validated on a cluster (cert cluster is down); the certified-operators submission
is being held until it can be install-tested.
