### PR TITLE
Add inititial Dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 50
+
+  # General Runtime Scans
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 50
+
+  - package-ecosystem: "gomod"
+    directory: "/operator"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 50
+
+  # Docker updates
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 50
+
+  - package-ecosystem: "docker"
+    directory: "/operator"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 50


### PR DESCRIPTION
**Addresses** #71 

Dependabot is an excellent tool to start with dependency scanning and update notifications.  There are other options such as adding extra Workflows and Jobs to them to handle similar tasks, or using something like Renovate, but Dependabot is built into the GitHub platform and performs many functions seamlessly.

This PR adds basic Dependabot configuration to cover the GitHub Actions, Go modules for the controller and operator, as well as the Container images.